### PR TITLE
Add `syntax-test-mode`, `division-by-undef-is-zero`, and `VOCABULARY_TYPE`

### DIFF
--- a/src/qlever/commands/example_queries.py
+++ b/src/qlever/commands/example_queries.py
@@ -92,6 +92,7 @@ class ExampleQueriesCommand(QleverCommand):
                 "text/csv",
                 "application/sparql-results+json",
                 "application/qlever-results+json",
+                "application/octet-stream",
                 "text/turtle",
                 "AUTO",
             ],

--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -39,6 +39,7 @@ class IndexCommand(QleverCommand):
                 "multi_input_json",
                 "parallel_parsing",
                 "settings_json",
+                "vocabulary_type",
                 "index_binary",
                 "only_pso_and_pos_permutations",
                 "ulimit",
@@ -184,6 +185,7 @@ class IndexCommand(QleverCommand):
             index_cmd = (
                 f"{args.cat_input_files} | {args.index_binary}"
                 f" -i {args.name} -s {args.name}.settings.json"
+                f" --vocabulary-type {args.vocabulary_type}"
                 f" -F {args.format} -f -"
             )
             if args.parallel_parsing:
@@ -199,6 +201,7 @@ class IndexCommand(QleverCommand):
             index_cmd = (
                 f"{args.index_binary}"
                 f" -i {args.name} -s {args.name}.settings.json"
+                f" --vocabulary-type {args.vocabulary_type}"
                 f" {input_options}"
             )
         else:

--- a/src/qlever/commands/query.py
+++ b/src/qlever/commands/query.py
@@ -72,6 +72,7 @@ class QueryCommand(QleverCommand):
                 "application/sparql-results+json",
                 "application/sparql-results+xml",
                 "application/qlever-results+json",
+                "application/octet-stream",
             ],
             default="text/tab-separated-values",
             help="Accept header for the SPARQL query",

--- a/src/qlever/commands/settings.py
+++ b/src/qlever/commands/settings.py
@@ -34,6 +34,7 @@ class SettingsCommand(QleverCommand):
             "cache-max-size-single-entry",
             "cache-service-results",
             "default-query-timeout",
+            "division-by-zero-is-undef",
             "group-by-disable-index-scan-optimizations",
             "group-by-hash-map-enabled",
             "lazy-index-scan-max-size-materialization",

--- a/src/qlever/commands/settings.py
+++ b/src/qlever/commands/settings.py
@@ -44,6 +44,7 @@ class SettingsCommand(QleverCommand):
             "request-body-limit",
             "service-max-value-rows",
             "sort-estimate-cancellation-factor",
+            "syntax-test-mode",
             "throw-on-unbound-variables",
             "use-binsearch-transitive-path",
         ]

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -116,6 +116,20 @@ class Qleverfile:
             "files (default: 1048576 when the total size of the input files "
             "is larger than 10 GB)",
         )
+        index_args["vocabulary_type"] = arg(
+            "--vocabulary-type",
+            type=str,
+            choices=[
+                "on-disk-compressed",
+                "on-disk-uncompressed",
+                "in-memory-compressed",
+                "in-memory-uncompressed",
+                "on-disk-compressed-geo-split",
+            ],
+            default="on-disk-compressed",
+            help="The type of the vocabulary to use for the index "
+            " (default: `on-disk-compressed`)",
+        )
         index_args["index_binary"] = arg(
             "--index-binary",
             type=str,

--- a/test/qlever/commands/test_index_execute.py
+++ b/test/qlever/commands/test_index_execute.py
@@ -40,6 +40,7 @@ class TestIndexCommand(unittest.TestCase):
         args.system = "native"
         args.show = False
         args.overwrite_existing = False
+        args.vocabulary_type = "on-disk-compressed"
         args.index_container = "test_container"
         args.image = "test_image"
         args.multi_input_json = False
@@ -61,6 +62,7 @@ class TestIndexCommand(unittest.TestCase):
         expected_index_cmd = (
             f"{args.cat_input_files} | {args.index_binary}"
             f" -i {args.name} -s {args.name}.settings.json"
+            f" --vocabulary-type {args.vocabulary_type}"
             f" -F {args.format} -f - | tee"
             f" {args.name}.index-log.txt"
         )
@@ -243,6 +245,7 @@ class TestIndexCommand(unittest.TestCase):
         args.system = "native"
         args.show = False
         args.overwrite_existing = False
+        args.vocabulary_type = "on-disk-compressed"
         args.index_container = "test_container"
         args.image = "test_image"
         args.multi_input_json = False
@@ -264,6 +267,7 @@ class TestIndexCommand(unittest.TestCase):
         expected_index_cmd = (
             f"ulimit -Sn 500000 && {args.cat_input_files} | {args.index_binary}"
             f" -i {args.name} -s {args.name}.settings.json"
+            f" --vocabulary-type {args.vocabulary_type}"
             f" -F {args.format} -f -"
             f" | tee {args.name}.index-log.txt"
         )
@@ -350,6 +354,7 @@ class TestIndexCommand(unittest.TestCase):
         args.input_files = "*.nt"
         args.system = "native"
         args.settings_json = '{"example": "settings"}'
+        args.vocabulary_type = "on-disk-compressed"
         args.show = True
         args.ulimit = None
         args.parser_buffer_size = None
@@ -364,6 +369,7 @@ class TestIndexCommand(unittest.TestCase):
         expected_index_cmd = (
             f"{args.index_binary}"
             f" -i {args.name} -s {args.name}.settings.json"
+            f" --vocabulary-type {args.vocabulary_type}"
             f" {mock_input_json.return_value}"
             f" --only-pso-and-pos-permutations --no-patterns"
             f" --no-patterns -w {args.name}.wordsfile.tsv"

--- a/test/qlever/commands/test_index_other_methods.py
+++ b/test/qlever/commands/test_index_other_methods.py
@@ -36,6 +36,7 @@ class TestIndexCommand(unittest.TestCase):
                     "multi_input_json",
                     "parallel_parsing",
                     "settings_json",
+                    "vocabulary_type",
                     "index_binary",
                     "only_pso_and_pos_permutations",
                     "ulimit",


### PR DESCRIPTION
Add choices `syntax-test-mode` and `division-by-zero-is-undef` for the `qlever settings` command, to enable the new functionality from https://github.com/ad-freiburg/qlever/pull/2127 ("Add runtime parameter syntax-test-mode for silently ignoring certain exceptions") and https://github.com/ad-freiburg/qlever/pull/2102 ("Make the behavior for division by zero configurable").

Add new variable `VOCABULARY_TYPE` for `[index]` section (and the corresponding `--vocabulary-type` option for the `qlever index` command), to enable the new functionality from https://github.com/ad-freiburg/qlever/pull/1740 ("Support uncompressed or fully in-memory vocabulary").