### PR TITLE
Add setting `spatial-join-prefilter-max-size` and `spatial-join-max-num-threads`

### DIFF
--- a/src/qlever/commands/settings.py
+++ b/src/qlever/commands/settings.py
@@ -46,6 +46,7 @@ class SettingsCommand(QleverCommand):
             "request-body-limit",
             "service-max-value-rows",
             "sort-estimate-cancellation-factor",
+            "spatial-join-prefilter-max-size",
             "syntax-test-mode",
             "throw-on-unbound-variables",
             "use-binsearch-transitive-path",

--- a/src/qlever/commands/settings.py
+++ b/src/qlever/commands/settings.py
@@ -47,6 +47,7 @@ class SettingsCommand(QleverCommand):
             "service-max-value-rows",
             "sort-estimate-cancellation-factor",
             "spatial-join-prefilter-max-size",
+            "spatial-join-max-num-threads",
             "syntax-test-mode",
             "throw-on-unbound-variables",
             "use-binsearch-transitive-path",


### PR DESCRIPTION
Support the runtime parameters introduced in https://github.com/ad-freiburg/qlever/pull/2242 and https://github.com/ad-freiburg/qlever/pull/2259