### PR TITLE
Add `ENCODE_AS_ID` and use in Qleverfiles for OSM and OHM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qlever"
 description = "Command-line tool for using the QLever graph database"
-version = "0.5.23"
+version = "0.5.24"
 authors = [
     { name = "Hannah Bast", email = "bast@cs.uni-freiburg.de" }
 ]

--- a/src/qlever/Qleverfiles/Qleverfile.ohm-planet
+++ b/src/qlever/Qleverfiles/Qleverfile.ohm-planet
@@ -11,7 +11,7 @@ NAME           = ohm-planet
 GET_DATA_URL   = https://planet.openhistoricalmap.org/planet
 CHECK_BINARIES = osm2rdf -h > /dev/null || (echo "osm2rdf not found, make sure that it's installed and in your PATH" && exit 1)
 GET_DATA_CMD_1 = unbuffer wget -O ${NAME}.pbf $$(curl -s ${GET_DATA_URL}/state.txt) 2>&1 | tee ${NAME}.download-log.txt
-GET_DATA_CMD_2 = osm2rdf ${NAME}.pbf -o ${NAME}.ttl --source-dataset OHM --output-compression gz --store-locations=disk-dense --cache . --num-threads 12 2>&1 | tee ${NAME}.osm2rdf-log.txt
+GET_DATA_CMD_2 = osm2rdf ${NAME}.pbf -o ${NAME}.ttl --source-dataset OHM --output-compression gz --store-locations=disk-dense --cache . --num-threads 12 --iri-prefix-for-untagged-nodes http://www.openhistoricalmap.org/node/ 2>&1 | tee ${NAME}.osm2rdf-log.txt
 GET_DATA_CMD   = ${CHECK_BINARIES} && ${GET_DATA_CMD_1} && echo && ${GET_DATA_CMD_2}
 VERSION        = $$(date -r ${NAME}.pbf +%d.%m.%Y || echo "NO_DATE")
 DESCRIPTION    = OHM Planet, data from ${GET_DATA_URL} version ${VERSION} (with GeoSPARQL predicates ogc:sfContains and ogc:sfIntersects)
@@ -22,6 +22,7 @@ MULTI_INPUT_JSON   = { "cmd": "zcat ${INPUT_FILES}", "parallel": "true" }
 STXXL_MEMORY       = 5G
 PARSER_BUFFER_SIZE = 50M
 SETTINGS_JSON      = { "num-triples-per-batch": 5000000 }
+ENCODE_AS_IDS      = https://www.openhistoricalmap.org/node/ http://www.openhistoricalmap.org/node/ https://www.openhistoricalmap.org/way/ https://www.openhistoricalmap.org/relation/ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_node_tagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_node_untagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_way_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_relation_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_wayarea_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_relationarea_ https://www.openstreetmap.org/changeset/
 
 [server]
 PORT                        = 7037

--- a/src/qlever/Qleverfiles/Qleverfile.osm-country
+++ b/src/qlever/Qleverfiles/Qleverfile.osm-country
@@ -16,7 +16,7 @@ NAME              = osm-${COUNTRY}
 PBF               = ${NAME}.pbf
 WITH_TEXT         = false
 VERSION           = $$(ls -l --time-style=+%d.%m.%Y ${PBF} 2> /dev/null | cut -d' ' -f6)
-GET_DATA_CMD      = wget -nc -O ${PBF} https://download.geofabrik.de/${CONTINENT}/${COUNTRY}-latest.osm.pbf; rm -f ${NAME}.*.bz2; ( time osm2rdf ${PBF} -o ${NAME}.ttl --cache . ) 2>&1 | tee ${NAME}.osm2rdf-log.txt; rm -f spatial-*
+GET_DATA_CMD      = wget -nc -O ${PBF} https://download.geofabrik.de/${CONTINENT}/${COUNTRY}-latest.osm.pbf; rm -f ${NAME}.*.bz2; ( time osm2rdf ${PBF} -o ${NAME}.ttl --cache . --iri-prefix-for-untagged-nodes http://www.openstreetmap.org/node/) 2>&1 | tee ${NAME}.osm2rdf-log.txt; rm -f spatial-*
 DESCRIPTION       = OSM ${COUNTRY}, dump from ${VERSION} with ogc:sfContains
 
 # Indexer settings
@@ -24,7 +24,8 @@ DESCRIPTION       = OSM ${COUNTRY}, dump from ${VERSION} with ogc:sfContains
 INPUT_FILES       = ${data:NAME}.ttl.bz2
 CAT_INPUT_FILES   = bzcat ${data:NAME}.ttl.bz2
 STXXL_MEMORY      = 10G
-SETTINGS_JSON     = { "prefixes-external": [ "\"LINESTRING(", "\"MULTIPOLYGON(", "\"POLYGON(" ], "ascii-prefixes-only": false, "num-triples-per-batch": 1000000 }
+SETTINGS_JSON      = { "num-triples-per-batch": 10000000 }
+ENCODE_AS_IDS      = https://www.openstreetmap.org/node/ http://www.openstreetmap.org/node/ https://www.openstreetmap.org/way/ https://www.openstreetmap.org/relation/ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_node_tagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_node_untagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_way_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_relation_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_wayarea_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_relationarea_ https://www.openstreetmap.org/changeset/
 
 # Server settings
 [server]

--- a/src/qlever/Qleverfiles/Qleverfile.osm-planet
+++ b/src/qlever/Qleverfiles/Qleverfile.osm-planet
@@ -11,7 +11,7 @@ NAME         = osm-planet
 DATA_URL     = https://osm2rdf.cs.uni-freiburg.de/ttl/planet.osm.ttl.bz2
 GET_DATA_CMD = unbuffer wget -O ${NAME}.ttl.bz2 ${DATA_URL} | tee ${NAME}.download-log.txt
 VERSION      = $$(date -r ${NAME}.ttl.bz2 +"%d.%m.%Y" || echo "NO_DATE")
-DESCRIPTION  = OSM Planet, data from ${DATA_URL} version ${VERSION} (complete OSM data, with GeoSPARQL predicates ogc:sfContains and ogc:sfIntersects)
+DESCRIPTION  = OSM from ${GET_DATA_URL} (converted to RDF using osm2rdf, enhanced by GeoSPARQL triples ogc:sfContains, ogc:sfCovers, ogc:sfIntersects, ogc:sfEquals, ogc:sfTouches, ogc:sfCrosses, ogc:sfOverlaps)
 
 [index]
 INPUT_FILES        = ${data:NAME}.ttl.bz2
@@ -21,6 +21,7 @@ PARSER_BUFFER_SIZE = 100M
 STXXL_MEMORY       = 40G
 SETTINGS_JSON      = { "num-triples-per-batch": 10000000 }
 ULIMIT             = 10000
+ENCODE_AS_IDS      = https://www.openstreetmap.org/node/ http://www.openstreetmap.org/node/ https://www.openstreetmap.org/way/ https://www.openstreetmap.org/relation/ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_node_tagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_node_untagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_way_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_relation_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_wayarea_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_relationarea_ https://www.openstreetmap.org/changeset/
 
 [server]
 PORT                        = 7007

--- a/src/qlever/Qleverfiles/Qleverfile.osm-planet
+++ b/src/qlever/Qleverfiles/Qleverfile.osm-planet
@@ -8,8 +8,8 @@
 
 [data]
 NAME         = osm-planet
-DATA_URL     = https://osm2rdf.cs.uni-freiburg.de/ttl/planet.osm.ttl.bz2
-GET_DATA_CMD = unbuffer wget -O ${NAME}.ttl.bz2 ${DATA_URL} | tee ${NAME}.download-log.txt
+GET_DATA_URL = https://osm2rdf.cs.uni-freiburg.de/ttl/planet.osm.ttl.bz2
+GET_DATA_CMD = unbuffer wget -O ${NAME}.ttl.bz2 ${GET_DATA_URL} | tee ${NAME}.download-log.txt
 VERSION      = $$(date -r ${NAME}.ttl.bz2 +"%d.%m.%Y" || echo "NO_DATE")
 DESCRIPTION  = OSM from ${GET_DATA_URL} (converted to RDF using osm2rdf, enhanced by GeoSPARQL triples ogc:sfContains, ogc:sfCovers, ogc:sfIntersects, ogc:sfEquals, ogc:sfTouches, ogc:sfCrosses, ogc:sfOverlaps)
 

--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -215,6 +215,8 @@ class IndexCommand(QleverCommand):
             return False
 
         # Add remaining options.
+        if args.encode_as_id:
+            index_cmd += f" --encode-as-id {args.encode_as_id}"
         if args.only_pso_and_pos_permutations:
             index_cmd += " --only-pso-and-pos-permutations --no-patterns"
         if not args.use_patterns:

--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -36,6 +36,7 @@ class IndexCommand(QleverCommand):
             "index": [
                 "input_files",
                 "cat_input_files",
+                "encode_as_id",
                 "multi_input_json",
                 "parallel_parsing",
                 "settings_json",

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -151,6 +151,14 @@ class Qleverfile:
             "large enough to contain the end of at least one statement "
             "(default: 10M)",
         )
+        index_args["encode_as_id"] = arg(
+            "--encode-as-id",
+            type=str,
+            help="Space-separated list of IRI prefixes (without angle "
+            "brackets); IRIs that start with one of these prefixes, followed "
+            "by a sequence of digits, do not require a vocabulary entry but "
+            "are directly encoded in the ID (default: none)",
+        )
         index_args["only_pso_and_pos_permutations"] = arg(
             "--only-pso-and-pos-permutations",
             action="store_true",

--- a/test/qlever/commands/test_index_execute.py
+++ b/test/qlever/commands/test_index_execute.py
@@ -45,6 +45,7 @@ class TestIndexCommand(unittest.TestCase):
         args.image = "test_image"
         args.multi_input_json = False
         args.ulimit = None
+        args.encode_as_id = None
         args.parser_buffer_size = None
 
         # Mock glob, get_total_file_size, get_existing_index_files,
@@ -250,6 +251,7 @@ class TestIndexCommand(unittest.TestCase):
         args.image = "test_image"
         args.multi_input_json = False
         args.ulimit = None
+        args.encode_as_id = None
         args.parser_buffer_size = None
 
         # Mock glob, get_total_file_size, get_existing_index_files,
@@ -357,6 +359,7 @@ class TestIndexCommand(unittest.TestCase):
         args.vocabulary_type = "on-disk-compressed"
         args.show = True
         args.ulimit = None
+        args.encode_as_id = None
         args.parser_buffer_size = None
 
         # Mock get_input_options_for_json

--- a/test/qlever/commands/test_index_other_methods.py
+++ b/test/qlever/commands/test_index_other_methods.py
@@ -33,6 +33,7 @@ class TestIndexCommand(unittest.TestCase):
                 "index": [
                     "input_files",
                     "cat_input_files",
+                    "encode_as_id",
                     "multi_input_json",
                     "parallel_parsing",
                     "settings_json",


### PR DESCRIPTION
This complements https://github.com/ad-freiburg/qlever/pull/2299

Use for `Qleverfile.osm-planet`, `Qleverfile.osm-country`, and `Qleverfile.ohm-planet`. While at it, also add the `--iri-prefix-for-untagged-node` argument to the `osm2rdf` calls.