### PR TITLE
New names regarding cache, due to qlever #1739

### DIFF
--- a/src/qlever/commands/cache_stats.py
+++ b/src/qlever/commands/cache_stats.py
@@ -17,43 +17,54 @@ class CacheStatsCommand(QleverCommand):
         pass
 
     def description(self) -> str:
-        return ("Show how much of the cache is currently being used")
+        return "Show how much of the cache is currently being used"
 
     def should_have_qleverfile(self) -> bool:
         return False
 
-    def relevant_qleverfile_arguments(self) -> dict[str: list[str]]:
+    def relevant_qleverfile_arguments(self) -> dict[str : list[str]]:
         return {"server": ["host_name", "port"]}
 
     def additional_arguments(self, subparser) -> None:
-        subparser.add_argument("--server-url",
-                               help="URL of the QLever server, default is "
-                               "{host_name}:{port}")
-        subparser.add_argument("--detailed",
-                               action="store_true",
-                               default=False,
-                               help="Show detailed statistics and settings")
+        subparser.add_argument(
+            "--server-url",
+            help="URL of the QLever server, default is {host_name}:{port}",
+        )
+        subparser.add_argument(
+            "--detailed",
+            action="store_true",
+            default=False,
+            help="Show detailed statistics and settings",
+        )
 
     def execute(self, args) -> bool:
         # Construct the two curl commands.
-        server_url = (args.server_url if args.server_url
-                      else f"{args.host_name}:{args.port}")
-        cache_stats_cmd = (f"curl -s {server_url} "
-                           f"--data-urlencode \"cmd=cache-stats\"")
-        cache_settings_cmd = (f"curl -s {server_url} "
-                              f"--data-urlencode \"cmd=get-settings\"")
+        server_url = (
+            args.server_url
+            if args.server_url
+            else f"{args.host_name}:{args.port}"
+        )
+        cache_stats_cmd = (
+            f'curl -s {server_url} --data-urlencode "cmd=cache-stats"'
+        )
+        cache_settings_cmd = (
+            f'curl -s {server_url} --data-urlencode "cmd=get-settings"'
+        )
 
         # Show them.
-        self.show("\n".join([cache_stats_cmd, cache_settings_cmd]),
-                  only_show=args.show)
+        self.show(
+            "\n".join([cache_stats_cmd, cache_settings_cmd]),
+            only_show=args.show,
+        )
         if args.show:
             return True
 
         # Execute them.
         try:
             cache_stats = subprocess.check_output(cache_stats_cmd, shell=True)
-            cache_settings = subprocess.check_output(cache_settings_cmd,
-                                                     shell=True)
+            cache_settings = subprocess.check_output(
+                cache_settings_cmd, shell=True
+            )
             cache_stats_dict = json.loads(cache_stats)
             cache_settings_dict = json.loads(cache_settings)
         except Exception as e:
@@ -64,27 +75,35 @@ class CacheStatsCommand(QleverCommand):
         if not args.detailed:
             cache_size = cache_settings_dict["cache-max-size"]
             if not cache_size.endswith(" GB"):
-                log.error(f"Cache size {cache_size} is not in GB, "
-                          f"QLever should return bytes instead")
+                log.error(
+                    f"Cache size {cache_size} is not in GB, "
+                    f"QLever should return bytes instead"
+                )
                 return False
             else:
                 cache_size = float(cache_size[:-3])
-            pinned_size = cache_stats_dict["pinned-size"] / 1e9
-            non_pinned_size = cache_stats_dict["non-pinned-size"] / 1e9
+            pinned_size = cache_stats_dict["cache-size-pinned"] / 1e9
+            non_pinned_size = cache_stats_dict["cache-size-unpinned"] / 1e9
             cached_size = pinned_size + non_pinned_size
             free_size = cache_size - cached_size
             if cached_size == 0:
                 log.info(f"Cache is empty, all {cache_size:.1f} GB available")
             else:
-                log.info(f"Pinned queries     : "
-                         f"{pinned_size:5.1f} GB of {cache_size:5.1f} GB"
-                         f"  [{pinned_size / cache_size:5.1%}]")
-                log.info(f"Non-pinned queries : "
-                         f"{non_pinned_size:5.1f} GB of {cache_size:5.1f} GB"
-                         f"  [{non_pinned_size / cache_size:5.1%}]")
-                log.info(f"FREE               : "
-                         f"{free_size:5.1f} GB of {cache_size:5.1f} GB"
-                         f"  [{1 - cached_size / cache_size:5.1%}]")
+                log.info(
+                    f"Pinned queries     : "
+                    f"{pinned_size:5.1f} GB of {cache_size:5.1f} GB"
+                    f"  [{pinned_size / cache_size:5.1%}]"
+                )
+                log.info(
+                    f"Non-pinned queries : "
+                    f"{non_pinned_size:5.1f} GB of {cache_size:5.1f} GB"
+                    f"  [{non_pinned_size / cache_size:5.1%}]"
+                )
+                log.info(
+                    f"FREE               : "
+                    f"{free_size:5.1f} GB of {cache_size:5.1f} GB"
+                    f"  [{1 - cached_size / cache_size:5.1%}]"
+                )
             return True
 
         # Complete version.
@@ -96,6 +115,7 @@ class CacheStatsCommand(QleverCommand):
                 if re.match(r"^\d+\.\d+$", value):
                     value = "{:.2f}".format(float(value))
                 log.info(f"{key.ljust(max_key_len)} : {value}")
+
         show_dict_as_table(cache_stats_dict.items())
         log.info("")
         show_dict_as_table(cache_settings_dict.items())

--- a/src/qlever/commands/query.py
+++ b/src/qlever/commands/query.py
@@ -95,7 +95,7 @@ class QueryCommand(QleverCommand):
         if args.pin_to_cache:
             args.accept = "application/qlever-results+json"
             curl_cmd_additions = (
-                f" --data pinresult=true --data send=0"
+                f" --data pin-result=true --data send=0"
                 f" --data access-token="
                 f"{shlex.quote(args.access_token)}"
                 f" | jq .resultsize | numfmt --grouping"

--- a/test/qlever/commands/test_cache_stats_execute.py
+++ b/test/qlever/commands/test_cache_stats_execute.py
@@ -29,13 +29,13 @@ class TestCacheStatsCommand(unittest.TestCase):
         # Mock `subprocess.check_output` and `json.loads` as encoded bytes
         mock_check_output.side_effect = [
             # Mock cache_stats
-            b'{"pinned-size": 1e9, "non-pinned-size": 3e9}',
+            b'{"cache-size-pinned": 1e9, "cache-size-unpinned": 3e9}',
             # Mock cache_settings
             b'{"cache-max-size": "10 GB"}',
         ]
         # mock cache_stats_dict and cache_settings_dict as a dictionary
         mock_json_loads.side_effect = [
-            {"pinned-size": 1e9, "non-pinned-size": 3e9},
+            {"cache-size-pinned": 1e9, "cache-size-unpinned": 3e9},
             {"cache-max-size": "10 GB"},
         ]
 
@@ -83,14 +83,14 @@ class TestCacheStatsCommand(unittest.TestCase):
 
         # Mock the responses from `subprocess.check_output` and `json.loads`
         mock_check_output.side_effect = [
-            b'{"pinned-size": 2e9, "non-pinned-size": 1e9, "test-stat": 500}',
+            b'{"cache-size-pinned": 2e9, "cache-size-unpinned": 1e9, "test-stat": 500}',
             b'{"cache-max-size": "10 GB", "test-setting": 1000}',
         ]
         # CAREFUL: if value is float you will get an error in re.match
         mock_json_loads.side_effect = [
             {
-                "pinned-size": int(2e9),
-                "non-pinned-size": int(1e9),
+                "cache-size-pinned": int(2e9),
+                "cache-size-unpinned": int(1e9),
                 "test-stat": 500,
             },
             {"cache-max-size": "10 GB", "test-setting": 1000},
@@ -112,11 +112,11 @@ class TestCacheStatsCommand(unittest.TestCase):
         mock_check_output.assert_any_call(expected_settings_call, shell=True)
 
         # Verify that detailed stats and settings were logged as a table
-        mock_log.info.assert_any_call("pinned-size     : 2,000,000,000")
-        mock_log.info.assert_any_call("non-pinned-size : 1,000,000,000")
-        mock_log.info.assert_any_call("test-stat       : 500")
-        mock_log.info.assert_any_call("cache-max-size : 10 GB")
-        mock_log.info.assert_any_call("test-setting   : 1,000")
+        mock_log.info.assert_any_call("cache-max-size      : 10 GB")
+        mock_log.info.assert_any_call("cache-size-pinned   : 2,000,000,000")
+        mock_log.info.assert_any_call("cache-size-unpinned : 1,000,000,000")
+        mock_log.info.assert_any_call("test-stat           : 500")
+        mock_log.info.assert_any_call("test-setting        : 1,000")
 
         self.assertTrue(result)
 
@@ -196,11 +196,11 @@ class TestCacheStatsCommand(unittest.TestCase):
 
         # Mock the responses with empty cache size
         mock_check_output.side_effect = [
-            b'{"pinned-size": 0, "non-pinned-size": 0}',
+            b'{"cache-size-pinned": 0, "cache-size-unpinned": 0}',
             b'{"cache-max-size": "10 GB"}',
         ]
         mock_json_loads.side_effect = [
-            {"pinned-size": 0, "non-pinned-size": 0},
+            {"cache-size-pinned": 0, "cache-size-unpinned": 0},
             {"cache-max-size": "10 GB"},
         ]
 

--- a/test/qlever/commands/test_cache_stats_execute.py
+++ b/test/qlever/commands/test_cache_stats_execute.py
@@ -112,11 +112,11 @@ class TestCacheStatsCommand(unittest.TestCase):
         mock_check_output.assert_any_call(expected_settings_call, shell=True)
 
         # Verify that detailed stats and settings were logged as a table
-        mock_log.info.assert_any_call("cache-max-size      : 10 GB")
+        mock_log.info.assert_any_call("cache-max-size : 10 GB")
         mock_log.info.assert_any_call("cache-size-pinned   : 2,000,000,000")
         mock_log.info.assert_any_call("cache-size-unpinned : 1,000,000,000")
         mock_log.info.assert_any_call("test-stat           : 500")
-        mock_log.info.assert_any_call("test-setting        : 1,000")
+        mock_log.info.assert_any_call("test-setting   : 1,000")
 
         self.assertTrue(result)
 


### PR DESCRIPTION
As a side effect of https://github.com/ad-freiburg/qlever/pull/1739, the following names were changed:

1. The URL command `cmd=pinresult` is now called `cmd=pin-result`
2. The JSON key `pinned-size` is now called `cache-size-pinned`
3. The JSON key `non-pinned-size` is now called `cache-size-unpinned`