### PR TITLE
Also consider `rdf_[un]linked_shared_data` in `update-wikidata` command

### DIFF
--- a/src/qlever/commands/update_wikidata.py
+++ b/src/qlever/commands/update_wikidata.py
@@ -252,46 +252,74 @@ class UpdateWikidataCommand(QleverCommand):
                 # operation = event_data.get("operation")
                 rdf_added_data = event_data.get("rdf_added_data")
                 rdf_deleted_data = event_data.get("rdf_deleted_data")
+                rdf_linked_shared_data = event_data.get(
+                    "rdf_linked_shared_data"
+                )
+                rdf_unlinked_shared_data = event_data.get(
+                    "rdf_unlinked_shared_data"
+                )
 
                 # Process the to-be-deleted triples.
-                if rdf_deleted_data is not None:
-                    try:
-                        rdf_deleted_data = rdf_deleted_data.get("data")
-                        graph = Graph()
-                        log.debug(f"RDF deleted data: {rdf_deleted_data}")
-                        graph.parse(data=rdf_deleted_data, format="turtle")
-                        for s, p, o in graph:
-                            triple = f"{s.n3()} {p.n3()} {o.n3()}"
-                            # NOTE: In case there was a previous `insert` of that
-                            # triple, it is safe to remove that `insert`, but not
-                            # the `delete` (in case the triple is contained in the
-                            # original data).
-                            if triple in insert_triples:
-                                insert_triples.remove(triple)
-                            delete_triples.add(triple)
-                    except Exception as e:
-                        log.error(f"Error reading `rdf_deleted_data`: {e}")
-                        return False
+                for rdf_to_be_deleted in (
+                    rdf_deleted_data,
+                    rdf_unlinked_shared_data,
+                ):
+                    if rdf_to_be_deleted is not None:
+                        try:
+                            rdf_to_be_deleted_data = rdf_to_be_deleted.get(
+                                "data"
+                            )
+                            graph = Graph()
+                            log.debug(
+                                f"RDF to_be_deleted data: {rdf_to_be_deleted_data}"
+                            )
+                            graph.parse(
+                                data=rdf_to_be_deleted_data, format="turtle"
+                            )
+                            for s, p, o in graph:
+                                triple = f"{s.n3()} {p.n3()} {o.n3()}"
+                                # NOTE: In case there was a previous `insert` of that
+                                # triple, it is safe to remove that `insert`, but not
+                                # the `delete` (in case the triple is contained in the
+                                # original data).
+                                if triple in insert_triples:
+                                    insert_triples.remove(triple)
+                                delete_triples.add(triple)
+                        except Exception as e:
+                            log.error(
+                                f"Error reading `rdf_to_be_deleted_data`: {e}"
+                            )
+                            return False
 
                 # Process the to-be-added triples.
-                if rdf_added_data is not None:
-                    try:
-                        rdf_added_data = rdf_added_data.get("data")
-                        graph = Graph()
-                        log.debug("RDF added data: {rdf_added_data}")
-                        graph.parse(data=rdf_added_data, format="turtle")
-                        for s, p, o in graph:
-                            triple = f"{s.n3()} {p.n3()} {o.n3()}"
-                            # NOTE: In case there was a previous `delete` of that
-                            # triple, it is safe to remove that `delete`, but not
-                            # the `insert` (in case the triple is not contained in
-                            # the original data).
-                            if triple in delete_triples:
-                                delete_triples.remove(triple)
-                            insert_triples.add(triple)
-                    except Exception as e:
-                        log.error(f"Error reading `rdf_added_data`: {e}")
-                        return False
+                for rdf_to_be_added in (
+                    rdf_added_data,
+                    rdf_linked_shared_data,
+                ):
+                    if rdf_to_be_added is not None:
+                        try:
+                            rdf_to_be_added_data = rdf_to_be_added.get("data")
+                            graph = Graph()
+                            log.debug(
+                                "RDF to be added data: {rdf_to_be_added_data}"
+                            )
+                            graph.parse(
+                                data=rdf_to_be_added_data, format="turtle"
+                            )
+                            for s, p, o in graph:
+                                triple = f"{s.n3()} {p.n3()} {o.n3()}"
+                                # NOTE: In case there was a previous `delete` of that
+                                # triple, it is safe to remove that `delete`, but not
+                                # the `insert` (in case the triple is not contained in
+                                # the original data).
+                                if triple in delete_triples:
+                                    delete_triples.remove(triple)
+                                insert_triples.add(triple)
+                        except Exception as e:
+                            log.error(
+                                f"Error reading `rdf_to_be_added_data`: {e}"
+                            )
+                            return False
 
             except Exception as e:
                 log.error(f"Error reading data from message: {e}")


### PR DESCRIPTION
So far, the command `update-wikidata` only considered the parts `rdf_added_data` (triples that must be added) and `rdf_deleted_data` (triples that must be removed) of each message from the Wikidata update stream.

Now, the command also consider `rdf_linked_shared_data` (triples that must be added only in case they have not already been added, which might be the case) and `rdf_unlinked_shared_data` (triples that should be removed, but do not harm if they are not removed). See https://wikitech.wikimedia.org/wiki/Wikidata_Query_Service/Streaming_Updater/Public_Update_Stream

NOTE: With this change, messages where the value for `"operation"` is one of `"import"`, `"diff"` or `"reconcile"` are now processed properly. However, messages with `"operation": "delete"` are still not processed properly (because for these, all four of the `rdf_...` above are empty and a `DELETE WHERE` query would be needed).