### PR TITLE
Improved and added `Qleverfile` for OSM planet

### DIFF
--- a/.github/workflows/end-to-end-test-ubuntu.yml
+++ b/.github/workflows/end-to-end-test-ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
 
     steps:
       - name: Checkout the repository for the qlever script
@@ -41,10 +41,9 @@ jobs:
 
       - name: Build qlever binaries from source + download docker image
         run: |
-          sudo apt update
-          sudo apt install -y software-properties-common
-          sudo add-apt-repository -y ppa:mhier/libboost-latest
-          sudo apt install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.81-dev libboost-program-options1.81-dev libboost-iostreams1.81-dev libboost-url1.81-dev
+          sudo apt update && sudo apt install -y wget
+          wget https://apt.kitware.com/kitware-archive.sh && chmod +x kitware-archive.sh && ./kitware-archive.sh
+          sudo apt install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.83-dev libboost-program-options1.83-dev libboost-iostreams1.83-dev libboost-url1.83-dev libboost-container1.83-dev
           if [ ! -d qlever-code ]; then
             git clone https://github.com/ad-freiburg/qlever.git qlever-code; fi
           cd qlever-code

--- a/.github/workflows/end-to-end-test-ubuntu.yml
+++ b/.github/workflows/end-to-end-test-ubuntu.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build qlever binaries from source + download docker image
         run: |
           sudo apt update && sudo apt install -y wget
-          wget https://apt.kitware.com/kitware-archive.sh && chmod +x kitware-archive.sh && ./kitware-archive.sh
+          wget https://apt.kitware.com/kitware-archive.sh && chmod +x kitware-archive.sh && sudo ./kitware-archive.sh
           sudo apt install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.83-dev libboost-program-options1.83-dev libboost-iostreams1.83-dev libboost-url1.83-dev libboost-container1.83-dev
           if [ ! -d qlever-code ]; then
             git clone https://github.com/ad-freiburg/qlever.git qlever-code; fi

--- a/.github/workflows/end-to-end-test-ubuntu.yml
+++ b/.github/workflows/end-to-end-test-ubuntu.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           sudo apt update && sudo apt install -y wget
           wget https://apt.kitware.com/kitware-archive.sh && chmod +x kitware-archive.sh && sudo ./kitware-archive.sh
-          sudo apt install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.81-dev libboost-program-options1.81-dev libboost-iostreams1.81-dev libboost-url1.81-dev libboost-container1.81-dev
+          sudo apt install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.83-dev libboost-program-options1.83-dev libboost-iostreams1.83-dev libboost-url1.83-dev libboost-container1.83-dev
           if [ ! -d qlever-code ]; then
             git clone https://github.com/ad-freiburg/qlever.git qlever-code; fi
           cd qlever-code

--- a/.github/workflows/end-to-end-test-ubuntu.yml
+++ b/.github/workflows/end-to-end-test-ubuntu.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           sudo apt update && sudo apt install -y wget
           wget https://apt.kitware.com/kitware-archive.sh && chmod +x kitware-archive.sh && sudo ./kitware-archive.sh
-          sudo apt install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.83-dev libboost-program-options1.83-dev libboost-iostreams1.83-dev libboost-url1.83-dev libboost-container1.83-dev
+          sudo apt install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.81-dev libboost-program-options1.81-dev libboost-iostreams1.81-dev libboost-url1.81-dev libboost-container1.81-dev
           if [ ! -d qlever-code ]; then
             git clone https://github.com/ad-freiburg/qlever.git qlever-code; fi
           cd qlever-code

--- a/src/qlever/Qleverfiles/Qleverfile.osm-planet
+++ b/src/qlever/Qleverfiles/Qleverfile.osm-planet
@@ -15,7 +15,7 @@ DESCRIPTION  = OSM from ${GET_DATA_URL} (converted to RDF using osm2rdf, enhance
 
 [index]
 INPUT_FILES        = ${data:NAME}.ttl.bz2
-MULTI_INPUT_JSON   = { "cmd": "zcat ${INPUT_FILES}", "parallel": "true" }
+MULTI_INPUT_JSON   = { "cmd": "lbzcat -n 2 ${INPUT_FILES}", "parallel": "true" }
 VOCABULARY_TYPE    = on-disk-compressed-geo-split
 PARSER_BUFFER_SIZE = 100M
 STXXL_MEMORY       = 60G

--- a/src/qlever/Qleverfiles/Qleverfile.osm-planet
+++ b/src/qlever/Qleverfiles/Qleverfile.osm-planet
@@ -21,7 +21,7 @@ PARSER_BUFFER_SIZE = 100M
 STXXL_MEMORY       = 60G
 SETTINGS_JSON      = { "num-triples-per-batch": 10000000 }
 ULIMIT             = 50000
-ENCODE_AS_IDS      = https://www.openstreetmap.org/node/ http://www.openstreetmap.org/node/ https://www.openstreetmap.org/way/ https://www.openstreetmap.org/relation/ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmnode_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmnode_tagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmnode_untagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmway_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmrel_ https://www.openstreetmap.org/changeset/
+ENCODE_AS_IDS      = https://www.openstreetmap.org/node/ http://www.openstreetmap.org/node/ https://www.openstreetmap.org/way/ https://www.openstreetmap.org/relation/ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmnode_tagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmnode_untagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmway_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmrel_ https://www.openstreetmap.org/changeset/
 
 [server]
 PORT                        = 7007

--- a/src/qlever/Qleverfiles/Qleverfile.osm-planet
+++ b/src/qlever/Qleverfiles/Qleverfile.osm-planet
@@ -21,7 +21,7 @@ PARSER_BUFFER_SIZE = 100M
 STXXL_MEMORY       = 60G
 SETTINGS_JSON      = { "num-triples-per-batch": 10000000 }
 ULIMIT             = 50000
-ENCODE_AS_IDS      = https://www.openstreetmap.org/node/ http://www.openstreetmap.org/node/ https://www.openstreetmap.org/way/ https://www.openstreetmap.org/relation/ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmnode_tagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmnode_untagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmway_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmrel_ https://www.openstreetmap.org/changeset/
+ENCODE_AS_IDS      = https://www.openstreetmap.org/node/ http://www.openstreetmap.org/node/ https://www.openstreetmap.org/way/ https://www.openstreetmap.org/relation/ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmnode_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmway_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmrel_ https://www.openstreetmap.org/changeset/
 
 [server]
 PORT                        = 7007

--- a/src/qlever/Qleverfiles/Qleverfile.osm-planet-from-pbf
+++ b/src/qlever/Qleverfiles/Qleverfile.osm-planet-from-pbf
@@ -1,6 +1,6 @@
 # Qleverfile for OSM Planet, use with the QLever CLI (`pip install qlever`)
 #
-# qlever get-data  # download ~100 GB (pbf), convert with osm2rdf, ~200 B triples
+# qlever get-data  # download ~100 GB (pbf), convert with osm2rdf, ~200B triples
 # qlever index     # ~40 hours, ~60 GB RAM, ~2.5 TB index size on disk
 # qlever start     # a few seconds, adjust MEMORY_FOR_QUERIES as needed
 #
@@ -17,7 +17,7 @@ VERSION      = $$(date -r ${PLANET_PBF} +%d.%m.%Y || echo "NO_DATE")
 DESCRIPTION  = OSM from ${GET_DATA_URL}, converted to RDF using osm2rdf, enhanced by GeoSPARQL triples ogc:sfContains, ogc:sfCovers, ogc:sfIntersects, ogc:sfEquals, ogc:sfTouches, ogc:sfCrosses, ogc:sfOverlaps
 
 [index]
-INPUT_FILES        = ${data:NAME}.ttl.bz2
+INPUT_FILES        = ${data:NAME}.ttl.gz
 MULTI_INPUT_JSON   = { "cmd": "zcat ${INPUT_FILES}", "parallel": "true" }
 VOCABULARY_TYPE    = on-disk-compressed-geo-split
 PARSER_BUFFER_SIZE = 100M

--- a/src/qlever/Qleverfiles/Qleverfile.osm-planet-from-pbf
+++ b/src/qlever/Qleverfiles/Qleverfile.osm-planet-from-pbf
@@ -1,17 +1,20 @@
 # Qleverfile for OSM Planet, use with the QLever CLI (`pip install qlever`)
 #
-# qlever get-data  # downloads ~400 GB (ttl.bz2), ~100 B triples
-# qlever index     # ~20 hours, ~60 GB RAM, ~1.5 TB index size on disk
+# qlever get-data  # download ~100 GB (pbf), convert with osm2rdf, ~200 B triples
+# qlever index     # ~40 hours, ~60 GB RAM, ~2.5 TB index size on disk
 # qlever start     # a few seconds, adjust MEMORY_FOR_QUERIES as needed
 #
-# Measured on an AMD Ryzen 9 7950X with 128 GB RAM and 2 x 8 TB NVMe (04.01.2025)
+# Measured on an AMD Ryzen 9 9950X with 128 GB RAM and 4 x 8 TB NVMe (02.10.2025)
 
 [data]
 NAME         = osm-planet
-GET_DATA_URL = https://osm2rdf.cs.uni-freiburg.de/ttl/planet.osm.ttl.bz2
-GET_DATA_CMD = unbuffer wget -O ${NAME}.ttl.bz2 ${GET_DATA_URL} | tee ${NAME}.download-log.txt
-VERSION      = $$(date -r ${NAME}.ttl.bz2 +"%d.%m.%Y" || echo "NO_DATE")
-DESCRIPTION  = OSM from ${GET_DATA_URL} (converted to RDF using osm2rdf, enhanced by GeoSPARQL triples ogc:sfContains, ogc:sfCovers, ogc:sfIntersects, ogc:sfEquals, ogc:sfTouches, ogc:sfCrosses, ogc:sfOverlaps)
+PLANET_PBF   = planet-250929.osm.pbf
+GET_DATA_URL = https://planet.openstreetmap.org/pbf/${PLANET_PBF}
+GET_PBF_CMD  = unbuffer wget -O ${PLANET_PBF} ${GET_DATA_URL}
+OSM2RDF_CMD  = unbuffer osm2rdf ${PLANET_PBF} -o ${NAME}.ttl --num-threads 20 --output-compression gz --cache . --store-locations disk-dense --iri-prefix-for-untagged-nodes http://www.openstreetmap.org/node/ --split-tag-key-by-semicolon ref --split-tag-key-by-semicolon service
+GET_DATA_CMD = ${GET_PBF_CMD} && ${OSM2RDF_CMD} 2>&1 | tee ${NAME}.osm2rdf-log.txt
+VERSION      = $$(date -r ${PLANET_PBF} +%d.%m.%Y || echo "NO_DATE")
+DESCRIPTION  = OSM from ${GET_DATA_URL}, converted to RDF using osm2rdf, enhanced by GeoSPARQL triples ogc:sfContains, ogc:sfCovers, ogc:sfIntersects, ogc:sfEquals, ogc:sfTouches, ogc:sfCrosses, ogc:sfOverlaps
 
 [index]
 INPUT_FILES        = ${data:NAME}.ttl.bz2
@@ -28,7 +31,7 @@ PORT                        = 7007
 ACCESS_TOKEN                = ${data:NAME}
 MEMORY_FOR_QUERIES          = 40G
 CACHE_MAX_SIZE              = 20G
-CACHE_MAX_SIZE_SINGLE_ENTRY = 20G
+CACHE_MAX_SIZE_SINGLE_ENTRY = 10G
 TIMEOUT                     = 600s
 
 [runtime]

--- a/src/qlever/Qleverfiles/Qleverfile.osm-planet-from-pbf
+++ b/src/qlever/Qleverfiles/Qleverfile.osm-planet-from-pbf
@@ -24,7 +24,7 @@ PARSER_BUFFER_SIZE = 100M
 STXXL_MEMORY       = 60G
 SETTINGS_JSON      = { "num-triples-per-batch": 10000000 }
 ULIMIT             = 50000
-ENCODE_AS_IDS      = https://www.openstreetmap.org/node/ http://www.openstreetmap.org/node/ https://www.openstreetmap.org/way/ https://www.openstreetmap.org/relation/ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmnode_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmnode_tagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmnode_untagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmway_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmrel_ https://www.openstreetmap.org/changeset/
+ENCODE_AS_IDS      = https://www.openstreetmap.org/node/ http://www.openstreetmap.org/node/ https://www.openstreetmap.org/way/ https://www.openstreetmap.org/relation/ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmnode_tagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmnode_untagged_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmway_ https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osmrel_ https://www.openstreetmap.org/changeset/
 
 [server]
 PORT                        = 7007

--- a/src/qlever/Qleverfiles/Qleverfile.uniprot
+++ b/src/qlever/Qleverfiles/Qleverfile.uniprot
@@ -55,8 +55,8 @@ MULTI_INPUT_JSON = [{ "cmd": "zcat {}", "graph": "http://sparql.uniprot.org/unip
                     { "cmd": "zcat ${data:TTL_DIR}/examples_uniprot.ttl.gz", "graph": "http://sparql.uniprot.org/.well-known/sparql-examples" },
                     { "cmd": "zcat ${data:TTL_DIR}/core.ttl.gz", "graph": "http://purl.uniprot.org/core" }]
 SETTINGS_JSON    = { "languages-internal": [], "prefixes-external": [""], "locale": { "language": "en", "country": "US", "ignore-punctuation": true }, "ascii-prefixes-only": true, "num-triples-per-batch": 25000000 }
-STXXL_MEMORY     = 60G
-ULIMIT           = 10000
+STXXL_MEMORY     = 80G
+ULIMIT           = 50000
 
 [server]
 PORT                        = 7018


### PR DESCRIPTION
1. Fix `ENCODED_AS_IDS` prefixes, see https://github.com/ad-freiburg/osm2rdf/pull/121
2. Set `VOCABULARY_TYPE = on-disk-compressed-geo-split`, see https://github.com/ad-freiburg/qlever/pull/1740
3. Add `Qleverfile` for OSM planet from PBF
4. Minor improvements

On the side, increase `ULIMIT` und `STXXL_MEMORY` for `Qleverfile.uniprot` and fix the Ubuntu end-to-end workflow (QLever requires an addition boost package since ad-freiburg/qlever#2415).