### PR TITLE
Consider `delete` operations in Wikidata update stream

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qlever"
 description = "Command-line tool for using the QLever graph database"
-version = "0.5.28"
+version = "0.5.30"
 authors = [
     { name = "Hannah Bast", email = "bast@cs.uni-freiburg.de" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qlever"
 description = "Command-line tool for using the QLever graph database"
-version = "0.5.30"
+version = "0.5.31"
 authors = [
     { name = "Hannah Bast", email = "bast@cs.uni-freiburg.de" }
 ]

--- a/src/qlever/commands/update_wikidata.py
+++ b/src/qlever/commands/update_wikidata.py
@@ -565,9 +565,9 @@ class UpdateWikidataCommand(QleverCommand):
                     time_us_per_op = int(1000 * time_ms / num_ops)
                     log.info(
                         colored(
-                            f"TRIPLES: {num_ops:+8,} -> {ops_after:8,}, "
-                            f"INS: {num_ins:+8,} -> {ins_after:8,}, "
-                            f"DEL: {num_del:+8,} -> {del_after:8,}, "
+                            f"TRIPLES: {num_ops:+10,} -> {ops_after:10,}, "
+                            f"INS: {num_ins:+10,} -> {ins_after:10,}, "
+                            f"DEL: {num_del:+10,} -> {del_after:10,}, "
                             f"TIME: {time_ms:7,} ms, "
                             f"TIME/TRIPLE: {time_us_per_op:6,} µs",
                             attrs=["bold"],
@@ -637,7 +637,7 @@ class UpdateWikidataCommand(QleverCommand):
             # After each batch, show total statistics so far.
             log.info(
                 colored(
-                    f"TOTAL TRIPLES SO FAR: {total_num_ops:8,}, "
+                    f"TOTAL TRIPLES SO FAR: {total_num_ops:10,}, "
                     f"TOTAL UPDATE TIME SO FAR: {total_time_s:4.0f} s, "
                     f"ELAPSED TIME SO FAR: {elapsed_time_s:4.0f} s, "
                     f"AVG TIME/TRIPLE SO FAR: {time_us_per_op:,} µs",
@@ -656,7 +656,7 @@ class UpdateWikidataCommand(QleverCommand):
         )
         log.info(
             colored(
-                f"TOTAL TRIPLES: {total_num_ops:8,}, "
+                f"TOTAL TRIPLES: {total_num_ops:10,}, "
                 f"TOTAL TIME: {total_time_s:4.0f} s, "
                 f"ELAPSED TIME: {elapsed_time_s:4.0f} s, "
                 f"AVG TIME/TRIPLE: {time_us_per_op:,} µs",

--- a/src/qlever/commands/update_wikidata.py
+++ b/src/qlever/commands/update_wikidata.py
@@ -283,10 +283,6 @@ class UpdateWikidataCommand(QleverCommand):
 
             # Process one event at a time.
             for event in source:
-                # Ctrl+C finishes the current batch.
-                if self.ctrl_c_pressed:
-                    break
-
                 # Skip events that are not of type `message` (should not
                 # happen), have no field `data` (should not happen either), or
                 # where the topic is not in `args.topics` (one topic by itself
@@ -463,6 +459,12 @@ class UpdateWikidataCommand(QleverCommand):
                 )
                 date_list.append(date)
                 delta_to_now_list.append(delta_to_now_s)
+
+                # Ctrl+C finishes the current batch (this should come at the
+                # end of the inner event loop so that always at least one
+                # message is processed).
+                if self.ctrl_c_pressed:
+                    break
 
             # Process the current batch of messages.
             batch_assembly_end_time = time.perf_counter()
@@ -674,6 +676,7 @@ class UpdateWikidataCommand(QleverCommand):
                         "execution",
                         "processUpdateImpl",
                         "updateMetadata",
+                        log_fail=False,
                     )
                     time_insert = get_time_ms(
                         stats,


### PR DESCRIPTION
So far, the `delete` operations were simply ignored. Now they are considered and executed in one `DELETE { ... } WHERE { ... }` at the end of each batch. When an added triple is encountered that has a subject that was deleted earlier in the batch, the batch is  finished and that added triple is processed in the next batch. It turns out that this happens rarely, even for a batch size of `100,000`.

On the side, improve the code structure, the logging, and the handling of Ctrl+C.