### PR TITLE
Fix Qleverfile for DBLP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qlever"
 description = "Command-line tool for using the QLever graph database"
-version = "0.5.28"
+version = "0.5.30"
 authors = [
     { name = "Hannah Bast", email = "bast@cs.uni-freiburg.de" }
 ]

--- a/src/qlever/Qleverfiles/Qleverfile.dblp
+++ b/src/qlever/Qleverfiles/Qleverfile.dblp
@@ -18,7 +18,8 @@ FORMAT       = ttl
 [index]
 INPUT_FILES      = *.gz
 MULTI_INPUT_JSON = { "cmd": "zcat {}", "for-each": "*.gz" }
-SETTINGS_JSON    = { "ascii-prefixes-only": false, "num-triples-per-batch": 5000000, "prefixes-external": [""] }
+SETTINGS_JSON    = { "num-triples-per-batch": 5000000 }
+STXXL_MEMORY     = 5G
 
 [server]
 PORT               = 7015


### PR DESCRIPTION
So far, `STXXL_MEMORY` was not set explicitly and the default value of `2G` was enough. However, with the increased dataset size of DBLP, this is no longer sufficient. This commit sets `STXXL_MEMORY = 5G`. On the side, simplify the `SETTINGS_JSON`.