### PR TITLE
Fix `--use-patterns` option of `qlever index` command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qlever"
 description = "Command-line tool for using the QLever graph database"
-version = "0.5.30"
+version = "0.5.31"
 authors = [
     { name = "Hannah Bast", email = "bast@cs.uni-freiburg.de" }
 ]

--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -220,7 +220,7 @@ class IndexCommand(QleverCommand):
             index_cmd += f" --encode-as-id {args.encode_as_id}"
         if args.only_pso_and_pos_permutations:
             index_cmd += " --only-pso-and-pos-permutations --no-patterns"
-        if not args.use_patterns:
+        if args.use_patterns == "no":
             index_cmd += " --no-patterns"
         if args.text_index in [
             "from_text_records",

--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -219,7 +219,7 @@ class IndexCommand(QleverCommand):
         if args.encode_as_id:
             index_cmd += f" --encode-as-id {args.encode_as_id}"
         if args.only_pso_and_pos_permutations:
-            index_cmd += " --only-pso-and-pos-permutations --no-patterns"
+            index_cmd += " --only-pso-and-pos-permutations"
         if args.use_patterns == "no":
             index_cmd += " --no-patterns"
         if args.text_index in [

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -34,7 +34,7 @@ def construct_command(args) -> str:
         start_cmd += " --persist-updates"
     if args.only_pso_and_pos_permutations:
         start_cmd += " --only-pso-and-pos-permutations"
-    if not args.use_patterns:
+    if args.use_patterns == "no":
         start_cmd += " --no-patterns"
     if args.use_text_index == "yes":
         start_cmd += " -t"

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -61,7 +61,7 @@ class Qleverfile:
             "--text-description",
             type=str,
             default=None,
-            help="A concise description of the additional text data" " if any",
+            help="A concise description of the additional text data if any",
         )
         data_args["format"] = arg(
             "--format",
@@ -438,6 +438,10 @@ class Qleverfile:
             server = config["server"]
         if index.get("text_index", "none") != "none":
             server["use_text_index"] = "yes"
+        if index.get("only_pso_and_pos_permutations", "false") == "true":
+            index["use_patterns"] = "no"
+        if index.get("use_patterns", None) == "no":
+            server["use_patterns"] = "no"
 
         # Add other non-trivial default values.
         try:

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -167,10 +167,10 @@ class Qleverfile:
         )
         index_args["use_patterns"] = arg(
             "--use-patterns",
-            action="store_true",
-            default=True,
-            help="Precompute so-called patterns needed for fast processing"
-            " of queries like SELECT ?p (COUNT(DISTINCT ?s) AS ?c) "
+            choices=["yes", "no"],
+            default="yes",
+            help="Whether to precompute the so-called patterns used for fast "
+            "processing of queries like SELECT ?p (COUNT(DISTINCT ?s) AS ?c) "
             "WHERE { ?s ?p [] ... } GROUP BY ?p",
         )
         index_args["text_index"] = arg(
@@ -283,10 +283,10 @@ class Qleverfile:
         )
         server_args["use_patterns"] = arg(
             "--use-patterns",
-            action="store_true",
-            default=True,
-            help="Use the patterns precomputed during the index build"
-            " (see `qlever index --help` for their utility)",
+            choices=["yes", "no"],
+            default="yes",
+            help="Whether to use the patterns precomputed during the index "
+            "build (see `qlever index --help` for their utility)",
         )
         server_args["use_text_index"] = arg(
             "--use-text-index",

--- a/test/qlever/commands/test_index_execute.py
+++ b/test/qlever/commands/test_index_execute.py
@@ -374,7 +374,7 @@ class TestIndexCommand(unittest.TestCase):
             f" -i {args.name} -s {args.name}.settings.json"
             f" --vocabulary-type {args.vocabulary_type}"
             f" {mock_input_json.return_value}"
-            f" --only-pso-and-pos-permutations --no-patterns"
+            f" --only-pso-and-pos-permutations"
             f" --no-patterns -w {args.name}.wordsfile.tsv"
             f" -d {args.name}.docsfile.tsv"
             f" --text-words-from-literals"

--- a/test/qlever/commands/test_index_execute.py
+++ b/test/qlever/commands/test_index_execute.py
@@ -350,7 +350,7 @@ class TestIndexCommand(unittest.TestCase):
         args.multi_input_json = True
         args.cat_input_files = False
         args.only_pso_and_pos_permutations = True
-        args.use_patterns = False
+        args.use_patterns = "no"
         args.text_index = "from_text_records_and_literals"
         args.stxxl_memory = True
         args.input_files = "*.nt"

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -22,7 +22,7 @@ def test_construct_command_with_if():
     args.persist_updates = False
     args.access_token = True
     args.only_pso_and_pos_permutations = True
-    args.use_patterns = False
+    args.use_patterns = "no"
     args.use_text_index = "yes"
 
     # Execute the function
@@ -331,7 +331,7 @@ class TestStartCommand(unittest.TestCase):
         args.persist_updates = False
         args.access_token = True
         args.only_pso_and_pos_permutations = True
-        args.use_patterns = False
+        args.use_patterns = "no"
         args.use_text_index = "yes"
 
         # Mock CacheStatsCommand


### PR DESCRIPTION
The previous implementation did not make sense. Now it's an option with choices `yes` and `no`. The default is `yes`. Also, propagate the following automatically in the Qleverfile:
1. When `ONLY_PSO_AND_POS_PERMUTATIONS` is set, then `USE_PATTERNS` is set to `no` in the `[index]` section
2. When `USE_PATTERNS` is set to `no` in the `[index]` section, then it is also set to `no` in the `[server]` section