### PR TITLE
Enable setting runtime parameters for `qlever start` command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qlever"
 description = "Command-line tool for using the QLever graph database"
-version = "0.5.31"
+version = "0.5.32"
 authors = [
     { name = "Hannah Bast", email = "bast@cs.uni-freiburg.de" }
 ]

--- a/src/qlever/commands/settings.py
+++ b/src/qlever/commands/settings.py
@@ -6,6 +6,7 @@ from termcolor import colored
 
 from qlever.command import QleverCommand
 from qlever.log import log
+from qlever.qleverfile import Qleverfile
 from qlever.util import run_command
 
 
@@ -27,39 +28,15 @@ class SettingsCommand(QleverCommand):
         return {"server": ["port", "host_name", "access_token"]}
 
     def additional_arguments(self, subparser) -> None:
-        all_keys = [
-            "always-multiply-unions",
-            "cache-max-num-entries",
-            "cache-max-size",
-            "cache-max-size-single-entry",
-            "cache-service-results",
-            "default-query-timeout",
-            "division-by-zero-is-undef",
-            "enable-prefilter-on-index-scans",
-            "group-by-disable-index-scan-optimizations",
-            "group-by-hash-map-enabled",
-            "lazy-index-scan-max-size-materialization",
-            "lazy-index-scan-num-threads",
-            "lazy-index-scan-queue-size",
-            "lazy-result-max-cache-size",
-            "query-planning-budget",
-            "request-body-limit",
-            "service-max-redirects",
-            "service-max-value-rows",
-            "sort-estimate-cancellation-factor",
-            "spatial-join-prefilter-max-size",
-            "spatial-join-max-num-threads",
-            "syntax-test-mode",
-            "throw-on-unbound-variables",
-            "treat-default-graph-as-named-graph",
-            "use-binsearch-transitive-path",
-        ]
         subparser.add_argument(
-            "key_value_pairs",
+            "runtime_parameters",
             nargs="*",
-            help="Space-separated list of key=value pairs to set; "
-            "afterwards shows all settings, with the changed ones highlighted",
-        ).completer = lambda **kwargs: [f"{key}=" for key in all_keys]
+            help="Space-separated list of runtime parameters to set "
+            "in the form `key=value`; afterwards shows all settings, "
+            "with the changed ones highlighted",
+        ).completer = lambda **kwargs: [
+            f"{key}=" for key in Qleverfile.SERVER_RUNTIME_PARAMETERS
+        ]
         subparser.add_argument(
             "--endpoint_url",
             type=str,
@@ -77,22 +54,22 @@ class SettingsCommand(QleverCommand):
         # Construct the `curl` commands for setting and getting.
         curl_cmds_setting = []
         keys_set = set()
-        if args.key_value_pairs:
-            for key_value_pair in args.key_value_pairs:
+        if args.runtime_parameters:
+            for key_value_pair in args.runtime_parameters:
                 try:
                     key, value = key_value_pair.split("=")
                 except ValueError:
                     log.error("Runtime parameter must be given as `key=value`")
                     return False
-
                 curl_cmds_setting.append(
-                    f"curl -s {endpoint_url}"
+                    f"curl -s {endpoint_url} -w %{{http_code}}"
                     f' --data-urlencode "{key}={value}"'
                     f' --data-urlencode "access-token={args.access_token}"'
                 )
                 keys_set.add(key)
         curl_cmd_getting = (
-            f"curl -s {endpoint_url} --data-urlencode cmd=get-settings"
+            f"curl -s {endpoint_url} -w %{{http_code}}"
+            f" --data-urlencode cmd=get-settings"
         )
         self.show(
             "\n".join(curl_cmds_setting + [curl_cmd_getting]),
@@ -104,7 +81,10 @@ class SettingsCommand(QleverCommand):
         # Execute the `curl` commands for setting the key-value pairs if any.
         for curl_cmd in curl_cmds_setting:
             try:
-                run_command(curl_cmd, return_output=False)
+                curl_result = run_command(curl_cmd, return_output=True)
+                body, http_code = curl_result[:-3], curl_result[-3:]
+                if http_code != "200":
+                    raise Exception(body)
             except Exception as e:
                 log.error(
                     f"curl command for setting key-value pair failed: {e}"
@@ -113,8 +93,11 @@ class SettingsCommand(QleverCommand):
 
         # Execute the `curl` commands for getting the settings.
         try:
-            settings_json = run_command(curl_cmd, return_output=True)
-            settings_dict = json.loads(settings_json)
+            curl_result = run_command(curl_cmd, return_output=True)
+            body, http_code = curl_result[:-3], curl_result[-3:]
+            if http_code != "200":
+                raise Exception(body)
+            settings_dict = json.loads(body)
             if isinstance(settings_dict, list):
                 settings_dict = settings_dict[0]
         except Exception as e:

--- a/src/qlever/commands/settings.py
+++ b/src/qlever/commands/settings.py
@@ -93,7 +93,7 @@ class SettingsCommand(QleverCommand):
 
         # Execute the `curl` commands for getting the settings.
         try:
-            curl_result = run_command(curl_cmd, return_output=True)
+            curl_result = run_command(curl_cmd_getting, return_output=True)
             body, http_code = curl_result[:-3], curl_result[-3:]
             if http_code != "200":
                 raise Exception(body)

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -5,6 +5,7 @@ import time
 
 from qlever.command import QleverCommand
 from qlever.commands.cache_stats import CacheStatsCommand
+from qlever.commands.settings import SettingsCommand
 from qlever.commands.status import StatusCommand
 from qlever.commands.stop import StopCommand
 from qlever.commands.warmup import WarmupCommand
@@ -151,6 +152,12 @@ class StartCommand(QleverCommand):
             help="If a QLever server is already running "
             "on the same port, kill it before "
             "starting a new server",
+        )
+        subparser.add_argument(
+            "--runtime-parameters",
+            help="Space-separated list of settings to apply right after "
+            "the server is up; see `qlever settings --help` for the "
+            "available choices",
         )
         subparser.add_argument(
             "--no-warmup",
@@ -304,6 +311,13 @@ class StartCommand(QleverCommand):
             args.detailed = False
             args.server_url = None
             CacheStatsCommand().execute(args)
+
+        # Apply settings if any.
+        if args.runtime_parameters:
+            args.key_value_pairs = args.runtime_parameters.split(" ")
+            args.endpoint_url = endpoint_url
+            log.info("")
+            SettingsCommand().execute(args)
 
         # With `--run-in-foreground`, wait until the server is stopped.
         if args.run_in_foreground:

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -21,6 +21,35 @@ class Qleverfile:
     Qleverfile + functions for parsing.
     """
 
+    # Runtime parameters (for `settings` and `start` commands).
+    SERVER_RUNTIME_PARAMETERS = [
+        "always-multiply-unions",
+        "cache-max-num-entries",
+        "cache-max-size",
+        "cache-max-size-single-entry",
+        "cache-service-results",
+        "default-query-timeout",
+        "division-by-zero-is-undef",
+        "enable-prefilter-on-index-scans",
+        "group-by-disable-index-scan-optimizations",
+        "group-by-hash-map-enabled",
+        "lazy-index-scan-max-size-materialization",
+        "lazy-index-scan-num-threads",
+        "lazy-index-scan-queue-size",
+        "lazy-result-max-cache-size",
+        "query-planning-budget",
+        "request-body-limit",
+        "service-max-redirects",
+        "service-max-value-rows",
+        "sort-estimate-cancellation-factor",
+        "spatial-join-prefilter-max-size",
+        "spatial-join-max-num-threads",
+        "syntax-test-mode",
+        "throw-on-unbound-variables",
+        "treat-default-graph-as-named-graph",
+        "use-binsearch-transitive-path",
+    ]
+
     @staticmethod
     def all_arguments():
         """

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -552,9 +552,7 @@ class TestStartCommand(unittest.TestCase):
         )
 
         # Check warmup was called
-        mock_run.assert_called_once_with(
-            args.warmup_cmd, shell=True, check=True
-        )
+        mock_run.assert_any_call(args.warmup_cmd, shell=True, check=True)
 
         # Assertions
         # Ensure the server status was checked

--- a/test/qlever/commands/test_start_other_methods.py
+++ b/test/qlever/commands/test_start_other_methods.py
@@ -65,7 +65,7 @@ class TestStartCommand(unittest.TestCase):
 
         # Test that the help text for
         # --kill-existing-with-same-port is correctly set
-        argument_help = subparser._group_actions[-3].help
+        argument_help = subparser._group_actions[-4].help
         self.assertEqual(
             argument_help,
             "If a QLever server is already running "

--- a/test/qlever/commands/test_start_other_methods.py
+++ b/test/qlever/commands/test_start_other_methods.py
@@ -77,5 +77,5 @@ class TestStartCommand(unittest.TestCase):
         self.assertEqual(args.no_warmup, False)
 
         # Test that the help text for --no-warmup is correctly set
-        argument_help = subparser._group_actions[-2].help
+        argument_help = subparser._group_actions[-3].help
         self.assertEqual(argument_help, "Do not execute the warmup command")


### PR DESCRIPTION
So far, runtime parameters could only be set via `qlever settings`, e.g., `qlever settings request-body-limit=10G`. However, this requires that the server is already running. Now this can also be done via `qlever start`, by simply appending the key-value pairs at the end, e.g., `qlever start --kill-existing-with-same-port request-body-limit=10G`. The settings are then set as soon as the server is  up. Multiple runtime parameters can be set by simply specifying multiple key-values pairs, separated by whitespace.

On the side, improved the error handling: when a runtime parameter does not exist or the value does not have the right format, an error message is shown that should make it clear what the problem was. 