### PR TITLE
Fix process iteration in `util.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qlever"
 description = "Command-line tool for using the QLever graph database"
-version = "0.5.32"
+version = "0.5.33"
 authors = [
     { name = "Hannah Bast", email = "bast@cs.uni-freiburg.de" }
 ]

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -287,8 +287,9 @@ def stop_process_with_regex(cmdline_regex: str) -> list[bool] | None:
             )
             cmdline = " ".join(pinfo["cmdline"])
         except Exception as e:
+            # For some processes (e.g., zombies), getting info may fail.
             log.debug(f"Error getting process info: {e}")
-            return None
+            continue
         if re.search(cmdline_regex, cmdline):
             log.info(
                 f"Found process {pinfo['pid']} from user "


### PR DESCRIPTION
The commands `qlever stop` and `qlever start` make use of a function `stop_process_with_regex` in `util.py`, which finds all processes matching a given regex. That function iterates over all processes and tries to get process info for each. Getting this info can fail, e.g., for zombie processes. So far, this caused the function to abort and the respective `qlever` command to fail. Now, such processes are simply skipped.