### PR TITLE
Add option `ADD_HAS_WORD_TRIPLES` for `qlever index` command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qlever"
 description = "Command-line tool for using the QLever graph database"
-version = "0.5.34"
+version = "0.5.35"
 authors = [
     { name = "Hannah Bast", email = "bast@cs.uni-freiburg.de" }
 ]

--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -45,6 +45,7 @@ class IndexCommand(QleverCommand):
                 "only_pso_and_pos_permutations",
                 "ulimit",
                 "use_patterns",
+                "add_has_word_triples",
                 "text_index",
                 "stxxl_memory",
                 "parser_buffer_size",
@@ -100,8 +101,7 @@ class IndexCommand(QleverCommand):
             # Check that `input_spec` is a dictionary.
             if not isinstance(input_spec, dict):
                 raise self.InvalidInputJson(
-                    f"Element {i} in `MULTI_INPUT_JSON` must be a JSON "
-                    "object",
+                    f"Element {i} in `MULTI_INPUT_JSON` must be a JSON object",
                     input_spec,
                 )
             # For each `input_spec`, we must have a command.
@@ -222,13 +222,14 @@ class IndexCommand(QleverCommand):
             index_cmd += " --only-pso-and-pos-permutations"
         if args.use_patterns == "no":
             index_cmd += " --no-patterns"
+        if args.add_has_word_triples:
+            index_cmd += " --add-has-word-triples"
         if args.text_index in [
             "from_text_records",
             "from_text_records_and_literals",
         ]:
             index_cmd += (
-                f" -w {args.name}.wordsfile.tsv"
-                f" -d {args.name}.docsfile.tsv"
+                f" -w {args.name}.wordsfile.tsv -d {args.name}.docsfile.tsv"
             )
         if args.text_index in [
             "from_literals",
@@ -306,8 +307,7 @@ class IndexCommand(QleverCommand):
         ):
             if Containerize.is_running(args.system, args.index_container):
                 log.info(
-                    "Another index process is running, trying to stop "
-                    "it ..."
+                    "Another index process is running, trying to stop it ..."
                 )
                 log.info("")
                 try:

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -203,6 +203,13 @@ class Qleverfile:
             "processing of queries like SELECT ?p (COUNT(DISTINCT ?s) AS ?c) "
             "WHERE { ?s ?p [] ... } GROUP BY ?p",
         )
+        index_args["add_has_word_triples"] = arg(
+            "--add-has-word-triples",
+            action="store_true",
+            default=False,
+            help="Whether to add `ql:has-word` triples for text literals "
+            "(which can then be used for custom text search queries)",
+        )
         index_args["text_index"] = arg(
             "--text-index",
             choices=[

--- a/test/qlever/commands/test_index_execute.py
+++ b/test/qlever/commands/test_index_execute.py
@@ -35,6 +35,7 @@ class TestIndexCommand(unittest.TestCase):
         args.only_pso_and_pos_permutations = False
         args.use_patterns = True
         args.parallel_parsing = False
+        args.add_has_word_triples = False
         args.text_index = "Test Index"
         args.stxxl_memory = False
         args.system = "native"
@@ -116,6 +117,7 @@ class TestIndexCommand(unittest.TestCase):
         args.input_files = "*.nt"
         args.only_pso_and_pos_permutations = False
         args.use_patterns = True
+        args.add_has_word_triples = False
         args.text_index = None
         args.stxxl_memory = None
         args.system = "native"
@@ -177,6 +179,7 @@ class TestIndexCommand(unittest.TestCase):
         args.input_files = "*.nt"
         args.only_pso_and_pos_permutations = False
         args.use_patterns = True
+        args.add_has_word_triples = False
         args.text_index = None
         args.stxxl_memory = None
         args.system = "native"
@@ -241,6 +244,7 @@ class TestIndexCommand(unittest.TestCase):
         args.only_pso_and_pos_permutations = False
         args.use_patterns = True
         args.parallel_parsing = False
+        args.add_has_word_triples = False
         args.text_index = None
         args.stxxl_memory = None
         args.system = "native"
@@ -351,6 +355,7 @@ class TestIndexCommand(unittest.TestCase):
         args.cat_input_files = False
         args.only_pso_and_pos_permutations = True
         args.use_patterns = "no"
+        args.add_has_word_triples = False
         args.text_index = "from_text_records_and_literals"
         args.stxxl_memory = True
         args.input_files = "*.nt"

--- a/test/qlever/commands/test_index_other_methods.py
+++ b/test/qlever/commands/test_index_other_methods.py
@@ -42,6 +42,7 @@ class TestIndexCommand(unittest.TestCase):
                     "only_pso_and_pos_permutations",
                     "ulimit",
                     "use_patterns",
+                    "add_has_word_triples",
                     "text_index",
                     "stxxl_memory",
                     "parser_buffer_size",


### PR DESCRIPTION
This complements https://github.com/ad-freiburg/qlever/pull/2579