### PR TITLE
Adapt to new `JSON` format returned for updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qlever"
 description = "Command-line tool for using the QLever graph database"
-version = "0.5.38"
+version = "0.5.39"
 authors = [
     { name = "Hannah Bast", email = "bast@cs.uni-freiburg.de" }
 ]


### PR DESCRIPTION
https://github.com/ad-freiburg/qlever/pull/2500 necessitates several changes in the `JSON` returned for updates. As a side effect, the statistics shown with `--verbose yes` (the default) are now more informative. In particular, the once-per-operation costs are now cleanly separated from the once-per-update costs