### PR TITLE
Add retry logic to `qlever update-wikidata` command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qlever"
 description = "Command-line tool for using the QLever graph database"
-version = "0.5.40"
+version = "0.5.41"
 authors = [
     { name = "Hannah Bast", email = "bast@cs.uni-freiburg.de" }
 ]


### PR DESCRIPTION
So far, the command failed when the stream or the SPARQL endpoint were temporarily unavailable. With this change, it will retry several times (and wait in between for a duration that increases with each failed attempt) before eventually giving up. The number of retries can be controlled via a new `--num-retries` argument