### PR TITLE
Rebuild index without change of directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qlever"
 description = "Command-line tool for using the QLever graph database"
-version = "0.5.42"
+version = "0.5.43"
 authors = [
     { name = "Hannah Bast", email = "bast@cs.uni-freiburg.de" }
 ]

--- a/src/qlever/commands/rebuild_index.py
+++ b/src/qlever/commands/rebuild_index.py
@@ -51,10 +51,32 @@ class RebuildIndexCommand(QleverCommand):
             "where the timestamp is the time of the earliest index file)",
         )
         subparser.add_argument(
+            "--new-index-dir-basename",
+            type=str,
+            default="rebuild.",
+            help="Basename prefix for the new index directory when "
+            "`--new-index-dir` is not specified (default: `rebuild.`)",
+        )
+        subparser.add_argument(
+            "--old-index-dir-basename",
+            type=str,
+            default="previous.",
+            help="Basename prefix for the old index directory when "
+            "`--old-index-dir` is not specified (default: `previous.`)",
+        )
+        subparser.add_argument(
+            "--keep-old-index-dirs",
+            choices=["all", "none", "oldest", "newest"],
+            default="oldest",
+            help="Which old index directories to keep: all (keep all), "
+            "none (delete all), oldest (keep only oldest), "
+            "newest (keep only newest) (default: oldest)",
+        )
+        subparser.add_argument(
             "--index-name",
             type=str,
-            help="Base name of the new index (default: use the same as the "
-            "current index)",
+            help="Base name of the files of the new index (default: use "
+            "the same basename as for the current index)",
         )
         subparser.add_argument(
             "--restart-when-finished",
@@ -101,9 +123,13 @@ class RebuildIndexCommand(QleverCommand):
         if args.index_name is None:
             args.index_name = args.name
         if args.new_index_dir is None:
-            args.new_index_dir = f"rebuild.{new_index_date}.tmp"
+            args.new_index_dir = (
+                f"{args.new_index_dir_basename}{new_index_date}.tmp"
+            )
             if args.old_index_dir is None:
-                args.old_index_dir = f"previous.{old_index_date}"
+                args.old_index_dir = (
+                    f"{args.old_index_dir_basename}{old_index_date}"
+                )
         if args.new_index_dir.endswith("/"):
             args.new_index_dir = args.new_index_dir[:-1]
 
@@ -194,7 +220,7 @@ class RebuildIndexCommand(QleverCommand):
         # being processed at the same time. It would be better if QLever
         # logged the rebuild-index output to a separate log file.
         tail_cmd = (
-            f"touch -c {new_index_dir_name}/{log_file_name} && "
+            f"touch {new_index_dir_name}/{log_file_name} && "
             f"exec tail -n 0 -f {new_index_dir_name}/{log_file_name}"
         )
         tail_proc = subprocess.Popen(tail_cmd, shell=True)
@@ -249,5 +275,41 @@ class RebuildIndexCommand(QleverCommand):
             except Exception as e:
                 log.error(f"Restarting the server failed: {e}")
                 return False
+
+        # List all subdirectories starting with `old_index_dir_basename`,
+        # ordered from oldest to newest (by creation time).
+        if move_old_index_when_done:
+            old_index_dirs = sorted(
+                [
+                    d
+                    for d in Path(".").iterdir()
+                    if d.is_dir()
+                    and d.name.startswith(args.old_index_dir_basename)
+                ],
+                key=lambda d: d.stat().st_ctime,
+            )
+            if old_index_dirs:
+                log.info("")
+                log.info(
+                    colored(
+                        f"Interate over old index directories (oldest to "
+                        f"newest), and check which ones to keep or delete "
+                        f"(keep_old_index_dirs = {args.keep_old_index_dirs}):",
+                        color="blue",
+                    )
+                )
+                for i, d in enumerate(old_index_dirs):
+                    is_oldest = i == 0
+                    is_newest = i == len(old_index_dirs) - 1
+                    if args.keep_old_index_dirs == "all":
+                        action = "KEEP"
+                    elif args.keep_old_index_dirs == "none":
+                        action = "DELETE"
+                    elif args.keep_old_index_dirs == "oldest":
+                        action = "KEEP" if is_oldest else "DELETE"
+                    elif args.keep_old_index_dirs == "newest":
+                        action = "KEEP" if is_newest else "DELETE"
+                    log.info(f"  {d.name:<50} {action}")
+                log.info("")
 
         return True

--- a/src/qlever/commands/rebuild_index.py
+++ b/src/qlever/commands/rebuild_index.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 import subprocess
 import time
 from pathlib import Path
@@ -9,6 +10,7 @@ from termcolor import colored
 from qlever.command import QleverCommand
 from qlever.log import log
 from qlever.util import (
+    get_existing_index_files,
     run_command,
 )
 
@@ -36,10 +38,17 @@ class RebuildIndexCommand(QleverCommand):
 
     def additional_arguments(self, subparser) -> None:
         subparser.add_argument(
-            "--index-dir",
+            "--new-index-dir",
             type=str,
-            help="Directory for the new index (default: subdirectory "
-            "`rebuild.YYYY-MM-DDTHH:MM` of the current directory)",
+            help="Target directory for the new index (default: not set, "
+            "move the old index instead; see `--old-index-dir`)",
+        )
+        subparser.add_argument(
+            "--old-index-dir",
+            type=str,
+            help="Directory where to move the current index once the rebuild "
+            "is finished (default: subdirectory `previous.YYYY-MM-DDTHH:MM`, "
+            "where the timestamp is the time of the earliest index file)",
         )
         subparser.add_argument(
             "--index-name",
@@ -56,60 +65,116 @@ class RebuildIndexCommand(QleverCommand):
         )
 
     def execute(self, args) -> bool:
-        # Default values for arguments.
-        if args.index_name is None:
-            args.index_name = args.name
-        if args.index_dir is None:
-            timestamp = time.strftime("%Y-%m-%dT%H:%M", time.localtime())
-            args.index_dir = f"rebuild.{timestamp}"
-        if args.index_dir.endswith("/"):
-            args.index_dir = args.index_dir[:-1]
-
-        # Check that the index directory either does not exist or is empty.
-        index_path = Path(args.index_dir)
-        if index_path.exists() and any(index_path.iterdir()):
+        # Either `--new-index-dir` or `--old-index-dir`.
+        if args.new_index_dir is not None and args.old_index_dir is not None:
             log.error(
-                f"The specified index directory '{args.index_dir}' already "
-                "exists and is not empty; please specify an empty or "
-                "non-existing directory"
+                "Please specify either --new-index-dir (the target directory "
+                "for the new index) or --old-index-dir (the directory where "
+                "to move the current index), but not both"
             )
             return False
 
-        # Split `index_dir` into path and dir name. For example, if `index_dir`
-        # is `path/to/index`, then the path is `path/to` and the dir name
-        # is `index`.
+        # Get the list of all files from the current index and get the date of
+        # the earliest one (in UTC). Add the `Qleverfile` as well.
+        old_index_files = get_existing_index_files(
+            args.name, add_non_essential=True
+        )
+        old_index_date = time.strftime(
+            "%Y-%m-%dT%H:%M:%SZ",
+            time.gmtime(min(Path(f).stat().st_mtime for f in old_index_files)),
+        )
+        new_index_date = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        old_index_files.append("Qleverfile")
+
+        # Default values for arguments.
+        #
+        # NOTE 1: When `--old-index-dir` is specified but not `--new-index-dir`,
+        # we nevertheless first build the new index in a temporary directory,
+        # and only when that is successful do we move the current index to the
+        # directory specified by `--old-index-dir` and move the new index to
+        # the current index directory. That way, if the rebuild fails, we still
+        # have the current index in its original location.
+        #
+        # NOTE 2: As a consequence of this logic, `args.new_index_dir` is
+        # always defined after this block, even when it was not specified on
+        # the command line.
+        if args.index_name is None:
+            args.index_name = args.name
+        if args.new_index_dir is None:
+            args.new_index_dir = f"rebuild.{new_index_date}.tmp"
+            if args.old_index_dir is None:
+                args.old_index_dir = f"previous.{old_index_date}"
+        if args.new_index_dir.endswith("/"):
+            args.new_index_dir = args.new_index_dir[:-1]
+
+        # Check that the new index directory either does not exist or is empty.
+        # Same for the old index directory, if specified.
+        new_index_path = Path(args.new_index_dir)
+        if new_index_path.exists() and any(new_index_path.iterdir()):
+            log.error(
+                f"The target directory '{args.new_index_dir}' for the new "
+                "index already exists and is not empty; please specify an "
+                "empty or non-existing directory"
+            )
+            return False
+        if args.old_index_dir is not None:
+            old_index_path = Path(args.old_index_dir)
+            if old_index_path.exists() and any(old_index_path.iterdir()):
+                log.error(
+                    f"The target directory '{args.old_index_dir}' for the "
+                    "old index already exists and is not empty; please "
+                    "specify an empty or non-existing directory"
+                )
+                return False
+
+        # Split `new_index_dir` into path and dir name. For example, if
+        # `new_index_dir` is `path/to/index`, then the path is `path/to` and
+        # the dir name is `index`.
         #
         # NOTE: We keep this separate because we can always create a
         # subdirectory in the current directory (even when running in a
         # container), but not necessarily a directory at an arbitrary path. If
         # a path outside the current directory is desired, we move the index
         # there after it has been built.
-        index_dir_path = str(Path(args.index_dir).parent)
-        index_dir_name = str(Path(args.index_dir).name)
+        new_index_dir_path = str(Path(args.new_index_dir).parent)
+        new_index_dir_name = str(Path(args.new_index_dir).name)
         log_file_name = f"{args.index_name}.rebuild-index-log.txt"
+
+        # Note which indexes we have to move when done.
+        move_new_index_when_done = new_index_dir_path != "."
+        move_old_index_when_done = args.old_index_dir is not None
 
         # Command for rebuilding the index.
         mkdir_cmd = (
-            f"mkdir -p {index_dir_name} && "
-            f"> {index_dir_name}/{log_file_name} && "
-            f"cp -a Qleverfile {index_dir_name}"
+            f"mkdir -p {new_index_dir_name} && "
+            f"cp -a Qleverfile {new_index_dir_name}"
         )
         rebuild_index_cmd = (
             f"curl -s {args.host_name}:{args.port} "
             f"-d cmd=rebuild-index "
-            f"-d index-name={index_dir_name}/{args.index_name} "
+            f"-d index-name={new_index_dir_name}/{args.index_name} "
             f"-d access-token={args.access_token}"
         )
-        move_index_cmd = f"mv {index_dir_name} {index_dir_path}"
-        restart_server_cmd = (
-            f"cd {args.index_dir} && "
-            f"qlever start --kill-existing-with-same-port"
+        move_new_index_cmd = f"mv {new_index_dir_name} {new_index_dir_path}"
+        move_old_index_cmd = (
+            f"mkdir -p {shlex.quote(args.old_index_dir)} && "
+            f"mv {' '.join(shlex.quote(f) for f in old_index_files)} "
+            f"{shlex.quote(args.old_index_dir)} && "
+            f"mv {shlex.quote(new_index_dir_name)}/* . && "
+            f"rmdir {shlex.quote(new_index_dir_name)}"
         )
+        restart_server_cmd = "qlever start --kill-existing-with-same-port"
+        if not move_old_index_when_done:
+            restart_server_cmd = (
+                f"cd {args.new_index_dir} && ${restart_server_cmd}"
+            )
 
         # Show the command lines.
         cmds_to_show = [mkdir_cmd, rebuild_index_cmd]
-        if index_dir_path != ".":
-            cmds_to_show.append(move_index_cmd)
+        if move_old_index_when_done:
+            cmds_to_show.append(move_old_index_cmd)
+        if move_new_index_when_done:
+            cmds_to_show.append(move_new_index_cmd)
         if args.restart_when_finished:
             cmds_to_show.append(restart_server_cmd)
         self.show("\n".join(cmds_to_show), only_show=args.show)
@@ -128,7 +193,10 @@ class RebuildIndexCommand(QleverCommand):
         # NOTE: This will only work satisfactorily when no other queries are
         # being processed at the same time. It would be better if QLever
         # logged the rebuild-index output to a separate log file.
-        tail_cmd = f"exec tail -n 0 -f {index_dir_name}/{log_file_name}"
+        tail_cmd = (
+            f"touch -c {new_index_dir_name}/{log_file_name} && "
+            f"exec tail -n 0 -f {new_index_dir_name}/{log_file_name}"
+        )
         tail_proc = subprocess.Popen(tail_cmd, shell=True)
 
         # Run the index rebuild command (and time it).
@@ -143,20 +211,29 @@ class RebuildIndexCommand(QleverCommand):
             duration_seconds = round(time_end - time_start)
             log.info("")
             rebuild_done_msg = f"Rebuilt index in {duration_seconds:,} seconds"
-            if index_dir_path == ".":
+            if new_index_dir_path == ".":
                 rebuild_done_msg += (
-                    f", in the new directory '{args.index_dir}'"
+                    f", in the new directory '{args.new_index_dir}'"
                 )
             log.info(rebuild_done_msg)
         finally:
             tail_proc.terminate()
             tail_proc.wait()
 
-        # Move the new index to the specified directory, if needed.
-        if index_dir_path != ".":
+        # Move the old index to the specified directory, if needed.
+        if move_old_index_when_done:
             try:
-                log.info(f"Moving the new index to {args.index_dir}")
-                run_command(move_index_cmd)
+                log.info(f"Moving the old index to {args.old_index_dir}")
+                run_command(move_old_index_cmd)
+            except Exception as e:
+                log.error(f"Moving the old index failed: {e}")
+                return False
+
+        # Move the new index to the specified directory, if needed.
+        if move_new_index_when_done:
+            try:
+                log.info(f"Moving the new index to {args.new_index_dir}")
+                run_command(move_new_index_cmd)
             except Exception as e:
                 log.error(f"Moving the new index failed: {e}")
                 return False

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -154,17 +154,28 @@ def is_qlever_server_alive(endpoint_url: str) -> bool:
         return False
 
 
-def get_existing_index_files(basename: str) -> list[str]:
+def get_existing_index_files(basename: str, add_non_essential: bool = False) -> list[str]:
     """
     Helper function that returns a list of all index files for `basename` in
     the current working directory.
     """
+
+    # Essential index files.
     existing_index_files = []
     existing_index_files.extend(Path.cwd().glob(f"{basename}.index.*"))
+    existing_index_files.extend(Path.cwd().glob(f"{basename}.internal.index.*"))
     existing_index_files.extend(Path.cwd().glob(f"{basename}.text.*"))
     existing_index_files.extend(Path.cwd().glob(f"{basename}.vocabulary.*"))
     existing_index_files.extend(Path.cwd().glob(f"{basename}.meta-data.json"))
     existing_index_files.extend(Path.cwd().glob(f"{basename}.prefixes"))
+
+    # Non-essential index files.
+    if add_non_essential:
+        existing_index_files.extend(Path.cwd().glob(f"{basename}.view.*"))
+        existing_index_files.extend(Path.cwd().glob(f"{basename}.settings.json"))
+        existing_index_files.extend(Path.cwd().glob(f"{basename}.index-log.txt"))
+        existing_index_files.extend(Path.cwd().glob(f"{basename}.server-log.txt"))
+
     # Return only the file names, not the full paths.
     return [path.name for path in existing_index_files]
 


### PR DESCRIPTION
There are now two separate options `--old-index-dir` (for moving the old index to a new directory) and `--new-index-dir` (for moving the rebuilt index to a new directory). Only one of them can be specified at a time. When `--old-index-dir` is specified (which it is now the default), the new index is built in a temporary directory and when the rebuild is successful, the old index files are moved to a separate directory (with default name `previous.<timestamp>`) and the new index files are moved to the current index directory. That way, even repeated rebuilds do NOT change the location of the current index, while previous indexes are kept in separate directories (by default, subdirectories of the current index directory)

There is also an option `--keep-old-index-dirs`, which controls which of the previous index directories are kept. The choices are `all` (keep all), `none` (keep none), `oldest` (keep only the directory with the original index), and `newest` (keep only the directory before the last rebuild). The default is `oldest`

On the side, add an option `--keep-update-requests` to the `qlever update-wikidata` command, with choices `none` (the files `update.{sparql,result,meta}` for each update request are removed after the request has been processed), `all` (the files are all kept), `last` (only the files of the last request are kept), and `last-three` (only the files of the last three requests are kept). The default is `last`