### PR TITLE
Validate the index after `rebuild-index`

### DIFF
--- a/src/qlever/commands/cache_stats.py
+++ b/src/qlever/commands/cache_stats.py
@@ -76,16 +76,22 @@ class CacheStatsCommand(QleverCommand):
         # Brief version.
         if not args.detailed:
             cache_size_str = cache_settings_dict["cache-max-size"]
-            unit_to_gb = {"B": 1e-9, "KB": 1e-6, "MB": 1e-3,
-                          "GB": 1, "TB": 1e3}
+            unit_to_gb = {
+                "B": 1e-9,
+                "KB": 1e-6,
+                "MB": 1e-3,
+                "GB": 1,
+                "TB": 1e3,
+            }
             cache_size = None
             for unit, factor in unit_to_gb.items():
                 if cache_size_str.endswith(f" {unit}"):
-                    cache_size = float(
-                        cache_size_str[:-len(unit) - 1]) * factor
+                    cache_size = (
+                        float(cache_size_str[: -len(unit) - 1]) * factor
+                    )
                     break
             if cache_size is None:
-                log.error(f"Cannot parse cache size: \"{cache_size_str}\"")
+                log.error(f'Cannot parse cache size: "{cache_size_str}"')
                 return False
             pinned_size = cache_stats_dict["cache-size-pinned"] / 1e9
             non_pinned_size = cache_stats_dict["cache-size-unpinned"] / 1e9

--- a/src/qlever/commands/cache_stats.py
+++ b/src/qlever/commands/cache_stats.py
@@ -75,15 +75,18 @@ class CacheStatsCommand(QleverCommand):
 
         # Brief version.
         if not args.detailed:
-            cache_size = cache_settings_dict["cache-max-size"]
-            if not cache_size.endswith(" GB"):
-                log.error(
-                    f"Cache size {cache_size} is not in GB, "
-                    f"QLever should return bytes instead"
-                )
+            cache_size_str = cache_settings_dict["cache-max-size"]
+            unit_to_gb = {"B": 1e-9, "KB": 1e-6, "MB": 1e-3,
+                          "GB": 1, "TB": 1e3}
+            cache_size = None
+            for unit, factor in unit_to_gb.items():
+                if cache_size_str.endswith(f" {unit}"):
+                    cache_size = float(
+                        cache_size_str[:-len(unit) - 1]) * factor
+                    break
+            if cache_size is None:
+                log.error(f"Cannot parse cache size: \"{cache_size_str}\"")
                 return False
-            else:
-                cache_size = float(cache_size[:-3])
             pinned_size = cache_stats_dict["cache-size-pinned"] / 1e9
             non_pinned_size = cache_stats_dict["cache-size-unpinned"] / 1e9
             cached_size = pinned_size + non_pinned_size

--- a/src/qlever/commands/rebuild_index.py
+++ b/src/qlever/commands/rebuild_index.py
@@ -40,9 +40,9 @@ def validate_index(args, index_dir: str) -> bool:
     validation_args = copy.copy(args)
     validation_args.port = validation_port
     validation_args.server_container = validation_container
-    validation_args.memory_for_queries = "1M"
-    validation_args.cache_max_size = "1M"
-    validation_args.cache_max_size_single_entry = "1M"
+    validation_args.memory_for_queries = "100M"
+    validation_args.cache_max_size = "10M"
+    validation_args.cache_max_size_single_entry = "10M"
     validation_args.timeout = "1s"
     validation_args.warmup_cmd = ""
     validation_args.show = False
@@ -54,6 +54,7 @@ def validate_index(args, index_dir: str) -> bool:
     validation_args.runtime_parameters = []
     validation_args.cmdline_regex = "qlever-server.* -i [^ ]*%%NAME%%"
     validation_args.no_containers = False
+    validation_args.restart_policy = "no"
 
     log.info(f"Validating new index in \"{index_dir}\" (port"
              f" {validation_port}) ...")
@@ -136,7 +137,8 @@ class RebuildIndexCommand(QleverCommand):
                 "use_text_index",
                 "warmup_cmd",
             ],
-            "runtime": ["system", "image", "server_container"],
+            "runtime": ["system", "image", "server_container",
+                        "restart_policy"],
         }
 
     def additional_arguments(self, subparser) -> None:

--- a/src/qlever/commands/rebuild_index.py
+++ b/src/qlever/commands/rebuild_index.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import copy
+import os
 import shlex
 import shutil
+import socket
 import subprocess
 import time
 from pathlib import Path
@@ -9,11 +12,86 @@ from pathlib import Path
 from termcolor import colored
 
 from qlever.command import QleverCommand
+from qlever.commands.start import StartCommand
+from qlever.commands.stop import StopCommand
 from qlever.log import log
 from qlever.util import (
     get_existing_index_files,
+    is_qlever_server_alive,
     run_command,
 )
+
+
+def validate_index(args, index_dir: str) -> bool:
+    """
+    Validate a newly built index by starting a temporary server on a
+    different port, sending a simple query, and checking that it succeeds.
+    Returns True if the index is usable, False otherwise.
+    """
+    # Find a free port and set the container name accordingly.
+    s = socket.socket()
+    s.bind(('', 0))
+    validation_port = s.getsockname()[1]
+    s.close()
+    validation_container = f"qlever-server.validate.{validation_port}"
+
+    # Create args for the validation server: minimal resources, different
+    # port and container name, working directory is the new index dir.
+    validation_args = copy.copy(args)
+    validation_args.port = validation_port
+    validation_args.server_container = validation_container
+    validation_args.memory_for_queries = "1M"
+    validation_args.cache_max_size = "1M"
+    validation_args.cache_max_size_single_entry = "1M"
+    validation_args.timeout = "1s"
+    validation_args.warmup_cmd = ""
+    validation_args.show = False
+
+    log.info(f"Validating new index in \"{index_dir}\" (port"
+             f" {validation_port}) ...")
+
+    # Start the validation server from the new index directory.
+    original_dir = Path.cwd()
+    try:
+        os.chdir(index_dir)
+        if not StartCommand().execute(validation_args):
+            log.error("Validation failed: could not start server")
+            return False
+    except Exception as e:
+        log.error(f"Validation failed: {e}")
+        return False
+    finally:
+        os.chdir(original_dir)
+
+    # Send a simple query to check the index works.
+    try:
+        endpoint = f"{args.host_name}:{validation_port}"
+        query_cmd = (
+            f"curl -s {endpoint}"
+            f" --data-urlencode \"query=SELECT * WHERE"
+            f" {{ ?s ?p ?o }} LIMIT 1\""
+            f" -o /dev/null -w \"%{{http_code}}\""
+        )
+        result = run_command(query_cmd, return_output=True)
+        query_ok = result.strip() == "200"
+    except Exception:
+        query_ok = False
+
+    # Stop the validation server.
+    try:
+        os.chdir(index_dir)
+        StopCommand().execute(validation_args)
+    except Exception:
+        pass
+    finally:
+        os.chdir(original_dir)
+
+    if query_ok:
+        log.info("Validation successful: new index is usable")
+    else:
+        log.error("Validation failed: server started but query failed")
+
+    return query_ok
 
 
 class RebuildIndexCommand(QleverCommand):
@@ -32,9 +110,25 @@ class RebuildIndexCommand(QleverCommand):
 
     def relevant_qleverfile_arguments(self) -> dict[str, list[str]]:
         return {
-            "data": ["name"],
-            "server": ["host_name", "port", "access_token"],
-            "runtime": ["server_container"],
+            "data": ["name", "description", "text_description"],
+            "server": [
+                "server_binary",
+                "host_name",
+                "port",
+                "access_token",
+                "memory_for_queries",
+                "cache_max_size",
+                "cache_max_size_single_entry",
+                "cache_max_num_entries",
+                "num_threads",
+                "timeout",
+                "persist_updates",
+                "only_pso_and_pos_permutations",
+                "use_patterns",
+                "use_text_index",
+                "warmup_cmd",
+            ],
+            "runtime": ["system", "image", "server_container"],
         }
 
     def additional_arguments(self, subparser) -> None:
@@ -66,12 +160,17 @@ class RebuildIndexCommand(QleverCommand):
             "`--old-index-dir` is not specified (default: `previous.`)",
         )
         subparser.add_argument(
-            "--keep-old-index-dirs",
-            choices=["all", "none", "oldest", "newest"],
-            default="oldest",
-            help="Which old index directories to keep: all (keep all), "
-            "none (delete all), oldest (keep only oldest), "
-            "newest (keep only newest) (default: oldest)",
+            "--keep-previous-index-dirs",
+            choices=["all", "none", "original-only", "most-recent-only",
+                     "original-and-most-recent"],
+            default="original-and-most-recent",
+            help="Which previous index directories to keep: "
+            "all (keep all), "
+            "none (delete all), "
+            "original-only (keep only the very first), "
+            "most-recent-only (keep only the most recently created), "
+            "original-and-most-recent (keep both) "
+            "(default: original-and-most-recent)",
         )
         subparser.add_argument(
             "--index-name",
@@ -254,6 +353,12 @@ class RebuildIndexCommand(QleverCommand):
             tail_proc.terminate()
             tail_proc.wait()
 
+        # Validate the new index before moving anything.
+        if not validate_index(args, new_index_dir_name):
+            log.error("The new index is dysfunctional, aborting. "
+                      f"Files are in \"{new_index_dir_name}\"")
+            return False
+
         # Move the old index to the specified directory, if needed.
         if move_old_index_when_done:
             try:
@@ -284,10 +389,11 @@ class RebuildIndexCommand(QleverCommand):
                 log.error(f"Restarting the server failed: {e}")
                 return False
 
-        # Clean up old index directories according to `--keep-old-index-dirs`.
-        # Find all subdirectories starting with `old_index_dir_basename`,
-        # ordered from oldest to newest (by creation time), and keep or delete
-        # them according to the specified policy.
+        # Clean up previous index directories according to
+        # `--keep-previous-index-dirs`. Find all subdirectories starting
+        # with `old_index_dir_basename`, ordered from oldest to newest
+        # (by creation time), and keep or delete them according to the
+        # specified policy.
         if move_old_index_when_done:
             old_index_dirs = sorted(
                 [
@@ -299,26 +405,30 @@ class RebuildIndexCommand(QleverCommand):
                 key=lambda dir: dir.stat().st_ctime,
             )
             if old_index_dirs:
+                policy = args.keep_previous_index_dirs
                 log.info("")
                 log.info(
                     colored(
-                        f"Iterate over old index directories (oldest to "
-                        f"newest), and check which ones to keep or delete "
-                        f"(keep_old_index_dirs = {args.keep_old_index_dirs}):",
+                        f"Iterate over previous index directories (oldest"
+                        f" to newest), and check which ones to keep or"
+                        f" delete (keep_previous_index_dirs = {policy}):",
                         color="blue",
                     )
                 )
                 for i, dir in enumerate(old_index_dirs):
-                    is_oldest = i == 0
-                    is_newest = i == len(old_index_dirs) - 1
-                    if args.keep_old_index_dirs == "all":
+                    is_original = i == 0
+                    is_most_recent = i == len(old_index_dirs) - 1
+                    if policy == "all":
                         action = "KEEP"
-                    elif args.keep_old_index_dirs == "none":
+                    elif policy == "none":
                         action = "DELETE"
-                    elif args.keep_old_index_dirs == "oldest":
-                        action = "KEEP" if is_oldest else "DELETE"
-                    elif args.keep_old_index_dirs == "newest":
-                        action = "KEEP" if is_newest else "DELETE"
+                    elif policy == "original-only":
+                        action = "KEEP" if is_original else "DELETE"
+                    elif policy == "most-recent-only":
+                        action = "KEEP" if is_most_recent else "DELETE"
+                    elif policy == "original-and-most-recent":
+                        action = ("KEEP" if is_original or is_most_recent
+                                  else "DELETE")
 
                     log.info(f"  {dir.name:<50} {action}")
 

--- a/src/qlever/commands/rebuild_index.py
+++ b/src/qlever/commands/rebuild_index.py
@@ -17,7 +17,6 @@ from qlever.commands.stop import StopCommand
 from qlever.log import log
 from qlever.util import (
     get_existing_index_files,
-    is_qlever_server_alive,
     run_command,
 )
 
@@ -30,7 +29,7 @@ def validate_index(args, index_dir: str) -> bool:
     """
     # Find a free port and set the container name accordingly.
     s = socket.socket()
-    s.bind(('', 0))
+    s.bind(("", 0))
     validation_port = s.getsockname()[1]
     s.close()
     validation_container = f"qlever-server.validate.{validation_port}"
@@ -56,8 +55,9 @@ def validate_index(args, index_dir: str) -> bool:
     validation_args.no_containers = False
     validation_args.restart_policy = "no"
 
-    log.info(f"Validating new index in \"{index_dir}\" (port"
-             f" {validation_port}) ...")
+    log.info(
+        f'Validating new index in "{index_dir}" (port {validation_port}) ...'
+    )
 
     # Start the validation server from the new index directory.
     original_dir = Path.cwd()
@@ -77,9 +77,9 @@ def validate_index(args, index_dir: str) -> bool:
         endpoint = f"{args.host_name}:{validation_port}"
         query_cmd = (
             f"curl -s {endpoint}"
-            f" --data-urlencode \"query=SELECT * WHERE"
-            f" {{ ?s ?p ?o }} LIMIT 1\""
-            f" -o /dev/null -w \"%{{http_code}}\""
+            f' --data-urlencode "query=SELECT * WHERE'
+            f' {{ ?s ?p ?o }} LIMIT 1"'
+            f' -o /dev/null -w "%{{http_code}}"'
         )
         result = run_command(query_cmd, return_output=True)
         query_ok = result.strip() == "200"
@@ -137,8 +137,12 @@ class RebuildIndexCommand(QleverCommand):
                 "use_text_index",
                 "warmup_cmd",
             ],
-            "runtime": ["system", "image", "server_container",
-                        "restart_policy"],
+            "runtime": [
+                "system",
+                "image",
+                "server_container",
+                "restart_policy",
+            ],
         }
 
     def additional_arguments(self, subparser) -> None:
@@ -171,8 +175,13 @@ class RebuildIndexCommand(QleverCommand):
         )
         subparser.add_argument(
             "--keep-previous-index-dirs",
-            choices=["all", "none", "original-only", "most-recent-only",
-                     "original-and-most-recent"],
+            choices=[
+                "all",
+                "none",
+                "original-only",
+                "most-recent-only",
+                "original-and-most-recent",
+            ],
             default="original-and-most-recent",
             help="Which previous index directories to keep: "
             "all (keep all), "
@@ -293,7 +302,7 @@ class RebuildIndexCommand(QleverCommand):
             f"cp -a Qleverfile {new_index_dir_name}"
         )
         rebuild_index_cmd = (
-            f"curl -s {args.host_name}:{args.port} "
+            f"curl -s -w '\\n%{{http_code}}' {args.host_name}:{args.port} "
             f"-d cmd=rebuild-index "
             f"-d index-name={new_index_dir_name}/{args.index_name} "
             f"-d access-token={args.access_token}"
@@ -337,8 +346,9 @@ class RebuildIndexCommand(QleverCommand):
         # being processed at the same time. It would be better if QLever
         # logged the rebuild-index output to a separate log file.
         tail_cmd = (
-            f"touch {new_index_dir_name}/{log_file_name} && "
-            f"exec tail -n 0 -f {new_index_dir_name}/{log_file_name}"
+            f"while [ ! -f {new_index_dir_name}/{log_file_name} ]; "
+            f"do sleep 0.1; done && "
+            f"exec tail -f {new_index_dir_name}/{log_file_name}"
         )
         tail_proc = subprocess.Popen(tail_cmd, shell=True)
 
@@ -346,7 +356,13 @@ class RebuildIndexCommand(QleverCommand):
         try:
             time_start = time.monotonic()
             try:
-                run_command(rebuild_index_cmd, show_output=False)
+                result = run_command(rebuild_index_cmd, return_output=True)
+                lines = result.rstrip("\n").rsplit("\n", 1)
+                http_code = lines[-1].strip() if len(lines) >= 2 else ""
+                response_body = lines[0] if len(lines) >= 2 else result
+                if http_code != "200":
+                    log.error(f"Rebuilding the index failed: {response_body}")
+                    return False
             except Exception as e:
                 log.error(f"Rebuilding the index failed: {e}")
                 return False
@@ -365,8 +381,10 @@ class RebuildIndexCommand(QleverCommand):
 
         # Validate the new index before moving anything.
         if not validate_index(args, new_index_dir_name):
-            log.error("The new index is dysfunctional, aborting. "
-                      f"Files are in \"{new_index_dir_name}\"")
+            log.error(
+                "The new index is dysfunctional, aborting. "
+                f'Files are in "{new_index_dir_name}"'
+            )
             return False
 
         # Move the old index to the specified directory, if needed.
@@ -437,8 +455,11 @@ class RebuildIndexCommand(QleverCommand):
                     elif policy == "most-recent-only":
                         action = "KEEP" if is_most_recent else "DELETE"
                     elif policy == "original-and-most-recent":
-                        action = ("KEEP" if is_original or is_most_recent
-                                  else "DELETE")
+                        action = (
+                            "KEEP"
+                            if is_original or is_most_recent
+                            else "DELETE"
+                        )
 
                     log.info(f"  {dir.name:<50} {action}")
 

--- a/src/qlever/commands/rebuild_index.py
+++ b/src/qlever/commands/rebuild_index.py
@@ -46,6 +46,14 @@ def validate_index(args, index_dir: str) -> bool:
     validation_args.timeout = "1s"
     validation_args.warmup_cmd = ""
     validation_args.show = False
+    # Additional arguments expected by StartCommand and StopCommand
+    # (normally set by argparse, but we call execute() directly).
+    validation_args.kill_existing_with_same_port = False
+    validation_args.no_warmup = True
+    validation_args.run_in_foreground = False
+    validation_args.runtime_parameters = []
+    validation_args.cmdline_regex = "qlever-server.* -i [^ ]*%%NAME%%"
+    validation_args.no_containers = False
 
     log.info(f"Validating new index in \"{index_dir}\" (port"
              f" {validation_port}) ...")

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -150,8 +150,12 @@ class StartCommand(QleverCommand):
                 "use_text_index",
                 "warmup_cmd",
             ],
-            "runtime": ["system", "image", "server_container",
-                        "restart_policy"],
+            "runtime": [
+                "system",
+                "image",
+                "server_container",
+                "restart_policy",
+            ],
         }
 
     def additional_arguments(self, subparser) -> None:
@@ -302,7 +306,8 @@ class StartCommand(QleverCommand):
             # If it exited (e.g. due to a corrupt index), stop waiting.
             if args.system in Containerize.supported_systems():
                 still_running = Containerize.is_running(
-                    args.system, args.server_container)
+                    args.system, args.server_container
+                )
             elif args.run_in_foreground:
                 still_running = process.poll() is None
             else:

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -66,7 +66,7 @@ def kill_existing_server(args) -> bool:
 def wrap_command_in_container(args, start_cmd) -> str:
     if not args.server_container:
         args.server_container = f"qlever.server.{args.name}"
-    run_subcmd = "run --restart=unless-stopped"
+    run_subcmd = f"run --restart={args.restart_policy}"
     if not args.run_in_foreground:
         run_subcmd += " -d"
     start_cmd = Containerize().containerize_command(
@@ -151,7 +151,8 @@ class StartCommand(QleverCommand):
                 "use_text_index",
                 "warmup_cmd",
             ],
-            "runtime": ["system", "image", "server_container"],
+            "runtime": ["system", "image", "server_container",
+                        "restart_policy"],
         }
 
     def additional_arguments(self, subparser) -> None:
@@ -298,6 +299,19 @@ class StartCommand(QleverCommand):
         if tail_proc is None:
             return False
         while not is_qlever_server_alive(args.endpoint_url):
+            # Check if the server process/container is still running.
+            # If it exited (e.g. due to a corrupt index), stop waiting.
+            if args.system in Containerize.supported_systems():
+                still_running = Containerize.is_running(
+                    args.system, args.server_container)
+            elif args.run_in_foreground:
+                still_running = process.poll() is None
+            else:
+                still_running = True  # nohup: can't easily check
+            if not still_running:
+                log.error("Server process exited before becoming ready")
+                tail_proc.terminate()
+                return False
             time.sleep(1)
 
         # Set the description for the index and text.

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -382,6 +382,15 @@ class Qleverfile:
             type=str,
             help=f"The name of the container used by `{script_name} start`",
         )
+        runtime_args["restart_policy"] = arg(
+            "--restart-policy",
+            type=str,
+            choices=["no", "always", "unless-stopped", "on-failure"],
+            default="unless-stopped",
+            help="Restart policy for the server container"
+            " (only applies when running in a container)"
+            " (default: unless-stopped)",
+        )
 
         ui_args["ui_port"] = arg(
             "--ui-port",

--- a/test/qlever/commands/test_cache_stats_execute.py
+++ b/test/qlever/commands/test_cache_stats_execute.py
@@ -161,12 +161,12 @@ class TestCacheStatsCommand(unittest.TestCase):
         # Mock the responses with invalid cache size format
         mock_check_output.side_effect = [
             b'{"pinned-size": 2e9, "non-pinned-size": 1e9}',
-            # Mock cache stats with invalid cache settings
-            b'{"cache-max-size": "1000 MB"}',
+            # Mock cache stats with unparseable cache settings
+            b'{"cache-max-size": "1000 XB"}',
         ]
         mock_json_loads.side_effect = [
             {"pinned-size": 2e9, "non-pinned-size": 1e9},
-            {"cache-max-size": "1000 MB"},
+            {"cache-max-size": "1000 XB"},
         ]
 
         # Execute the command
@@ -174,8 +174,7 @@ class TestCacheStatsCommand(unittest.TestCase):
 
         # Assertions to verify that error was logged
         mock_log.error.assert_called_once_with(
-            "Cache size 1000 MB is not in GB, QLever should return "
-            "bytes instead"
+            'Cannot parse cache size: "1000 XB"'
         )
 
         self.assertFalse(result)

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -94,6 +94,7 @@ def test_wrap_command_in_container(mock_containerize_command):
     args.system = "native"
     args.image = None
     args.run_in_foreground = False
+    args.restart_policy = "unless-stopped"
 
     # Mock wrap_command_in_container
     mock_containerize_command.return_value = "Test_Container_Command"

--- a/test/qlever/commands/test_start_other_methods.py
+++ b/test/qlever/commands/test_start_other_methods.py
@@ -44,7 +44,8 @@ class TestStartCommand(unittest.TestCase):
                     "use_text_index",
                     "warmup_cmd",
                 ],
-                "runtime": ["system", "image", "server_container"],
+                "runtime": ["system", "image", "server_container",
+                            "restart_policy"],
             },
         )
 

--- a/test/qlever/commands/test_start_other_methods.py
+++ b/test/qlever/commands/test_start_other_methods.py
@@ -44,8 +44,12 @@ class TestStartCommand(unittest.TestCase):
                     "use_text_index",
                     "warmup_cmd",
                 ],
-                "runtime": ["system", "image", "server_container",
-                            "restart_policy"],
+                "runtime": [
+                    "system",
+                    "image",
+                    "server_container",
+                    "restart_policy",
+                ],
             },
         )
 


### PR DESCRIPTION
When the API call `cmd=rebuild-index` to QLever succeeds, this does not necessarily mean that the index is valid. This could lead to a situation where the old index was replaced with an invalid new index.

With this change, the new index is validated before moving it to a new location or deleting the old index. The index is validated by starting a server with that index on a random free port and issuing a simple query to it. Only if the validation succeeds, does the command continue as before.

On the side, change the name of the option `--keep-old-index-dirs` to `--keep-previous-index-dirs`, which now has the options `all`, `none`, `original-only`, `most-recent-only`, and `original-and-most-recent`, where the latter is the new default. 

Also, avoid `touch`ing the log file before `tail`ing it. This became necessary after https://github.com/ad-freiburg/qlever/pull/2860, which aborts the `rebuild-index` process when it finds an existing file with the base name of the to-be-written index files, even if it's just the empty log file