### PR TITLE
Keep colored output when piping (for example, through `tee`)

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -20,12 +20,14 @@ jobs:
         id: lint
         continue-on-error: true
         with:
+          version: "0.15.2"
           args: "check"
       - name: Format
         uses: astral-sh/ruff-action@v4.0.0
         id: format
         continue-on-error: true
         with:
+          version: "0.15.2"
           args: "format --diff"
       - name: Fail if any check failed
         if: steps.lint.outcome == 'failure' || steps.format.outcome == 'failure'

--- a/src/qlever/qlever_main.py
+++ b/src/qlever/qlever_main.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import traceback
 
@@ -18,6 +19,13 @@ from qlever.log import log, log_levels
 
 
 def main():
+    # Color the output even when stdout is not a terminal (e.g. when piping
+    # through `tee`). Setting `NO_COLOR` still disables all colors, because
+    # `termcolor` gives it precedence over `FORCE_COLOR`. Note that
+    # `termcolor` evaluates these variables on each call to `colored`, so it
+    # is enough to set this here (and not before the imports above).
+    os.environ.setdefault("FORCE_COLOR", "1")
+
     # Parse the command line arguments and read the Qleverfile.
     try:
         qlever_config = QleverConfig()


### PR DESCRIPTION
So far, all colors were lost when the output of a `qlever` command was piped, for example, through `tee` to keep a log file. The reason is that the `termcolor` library disables colors whenever `stdout` is not a terminal.

With this change, `FORCE_COLOR` is set at the beginning of `main`, so that the output is colored also when piped. This works because `termcolor` evaluates the variable on each call to `colored`. Setting `NO_COLOR` still disables all colors, because `termcolor` gives it precedence over `FORCE_COLOR`.