### PR TITLE
Add --rebuild-index-strategy to qlever start

### DIFF
--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -43,7 +43,7 @@ def construct_command(args) -> str:
     # Only pass the flag for a non-default value, so that older server
     # binaries without this option keep working.
     if args.rebuild_index_strategy != "manual":
-        start_cmd += f" --rebuild-index-strategy {shlex.quote(args.rebuild_index_strategy)}"
+        start_cmd += f" --rebuild-index-strategy {args.rebuild_index_strategy}"
     if args.only_pso_and_pos_permutations:
         start_cmd += " --only-pso-and-pos-permutations"
     if args.use_patterns == "no":

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -40,6 +40,10 @@ def construct_command(args) -> str:
         start_cmd += f" -a {args.access_token}"
     if args.persist_updates:
         start_cmd += " --persist-updates"
+    # Only pass the flag for a non-default value, so that older server
+    # binaries without this option keep working.
+    if args.rebuild_index_strategy != "manual":
+        start_cmd += f" --rebuild-index-strategy {args.rebuild_index_strategy}"
     if args.only_pso_and_pos_permutations:
         start_cmd += " --only-pso-and-pos-permutations"
     if args.use_patterns == "no":
@@ -166,6 +170,7 @@ class StartCommand(QleverCommand):
                 "num_threads",
                 "timeout",
                 "persist_updates",
+                "rebuild_index_strategy",
                 "only_pso_and_pos_permutations",
                 "use_patterns",
                 "use_text_index",

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -43,7 +43,7 @@ def construct_command(args) -> str:
     # Only pass the flag for a non-default value, so that older server
     # binaries without this option keep working.
     if args.rebuild_index_strategy != "manual":
-        start_cmd += f" --rebuild-index-strategy {args.rebuild_index_strategy}"
+        start_cmd += f" --rebuild-index-strategy {shlex.quote(args.rebuild_index_strategy)}"
     if args.only_pso_and_pos_permutations:
         start_cmd += " --only-pso-and-pos-permutations"
     if args.use_patterns == "no":

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -360,6 +360,16 @@ class Qleverfile:
             help="Persist updates to the index (write updates to disk and "
             "read them back in when restarting the server)",
         )
+        server_args["rebuild_index_strategy"] = arg(
+            "--rebuild-index-strategy",
+            type=str,
+            default="manual",
+            help="When to rebuild the index from the current data (including "
+            'updates): "manual" (only when explicitly requested via '
+            "`qlever rebuild-index`) or a number (additionally rebuild "
+            "automatically in the background whenever the number of delta "
+            "triples exceeds that number)",
+        )
         server_args["only_pso_and_pos_permutations"] = arg(
             "--only-pso-and-pos-permutations",
             action="store_true",

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -366,9 +366,11 @@ class Qleverfile:
             default="manual",
             help="When to rebuild the index from the current data (including "
             'updates): "manual" (only when explicitly requested via '
-            "`qlever rebuild-index`) or a number (additionally rebuild "
-            "automatically in the background whenever the number of delta "
-            "triples exceeds that number)",
+            '`qlever rebuild-index`) or "min:max:fraction" (additionally '
+            "rebuild automatically in the background once the number of delta "
+            "triples reaches the given `fraction` of the number of index "
+            "triples, but never below `min` and always at `max`, "
+            'e.g. "10000:1000000:0.1")',
         )
         server_args["only_pso_and_pos_permutations"] = arg(
             "--only-pso-and-pos-permutations",

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -366,11 +366,11 @@ class Qleverfile:
             default="manual",
             help="When to rebuild the index from the current data (including "
             'updates): "manual" (only when explicitly requested via '
-            '`qlever rebuild-index`) or "min:max:fraction" (additionally '
+            '`qlever rebuild-index`) or "automatic:min:max:fraction" (additionally '
             "rebuild automatically in the background once the number of delta "
             "triples reaches the given `fraction` of the number of index "
             "triples, but never below `min` and always at `max`, "
-            'e.g. "10000:1000000:0.1")',
+            'e.g. "automatic:10000:1000000:0.1")',
         )
         server_args["only_pso_and_pos_permutations"] = arg(
             "--only-pso-and-pos-permutations",

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -20,6 +20,7 @@ def test_construct_command_with_if():
     args.cache_max_num_entries = 1000
     args.timeout = True
     args.persist_updates = False
+    args.rebuild_index_strategy = "100000"
     args.access_token = True
     args.only_pso_and_pos_permutations = True
     args.use_patterns = "no"
@@ -42,6 +43,7 @@ def test_construct_command_with_if():
         f" -k {args.cache_max_num_entries}"
         f" -s {args.timeout}"
         f" -a {args.access_token}"
+        " --rebuild-index-strategy 100000"
         " --only-pso-and-pos-permutations"
         " --no-patterns"
         " -t"
@@ -66,6 +68,7 @@ def test_construct_command_without_if():
     args.cache_max_num_entries = 1000
     args.timeout = False
     args.persist_updates = False
+    args.rebuild_index_strategy = "manual"
     args.access_token = False
     args.only_pso_and_pos_permutations = False
     args.use_patterns = True
@@ -368,6 +371,7 @@ class TestStartCommand(unittest.TestCase):
         args.run_in_foreground = False
         args.timeout = True
         args.persist_updates = False
+        args.rebuild_index_strategy = "manual"
         args.access_token = True
         args.only_pso_and_pos_permutations = True
         args.use_patterns = "no"

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -20,7 +20,7 @@ def test_construct_command_with_if():
     args.cache_max_num_entries = 1000
     args.timeout = True
     args.persist_updates = False
-    args.rebuild_index_strategy = "10000:1000000:0.1"
+    args.rebuild_index_strategy = "automatic:10000:1000000:0.1"
     args.access_token = True
     args.only_pso_and_pos_permutations = True
     args.use_patterns = "no"
@@ -43,7 +43,7 @@ def test_construct_command_with_if():
         f" -k {args.cache_max_num_entries}"
         f" -s {args.timeout}"
         f" -a {args.access_token}"
-        " --rebuild-index-strategy 10000:1000000:0.1"
+        " --rebuild-index-strategy automatic:10000:1000000:0.1"
         " --only-pso-and-pos-permutations"
         " --no-patterns"
         " -t"

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -20,7 +20,7 @@ def test_construct_command_with_if():
     args.cache_max_num_entries = 1000
     args.timeout = True
     args.persist_updates = False
-    args.rebuild_index_strategy = "100000"
+    args.rebuild_index_strategy = "10000:1000000:0.1"
     args.access_token = True
     args.only_pso_and_pos_permutations = True
     args.use_patterns = "no"
@@ -43,7 +43,7 @@ def test_construct_command_with_if():
         f" -k {args.cache_max_num_entries}"
         f" -s {args.timeout}"
         f" -a {args.access_token}"
-        " --rebuild-index-strategy 100000"
+        " --rebuild-index-strategy 10000:1000000:0.1"
         " --only-pso-and-pos-permutations"
         " --no-patterns"
         " -t"

--- a/test/qlever/commands/test_start_other_methods.py
+++ b/test/qlever/commands/test_start_other_methods.py
@@ -40,6 +40,7 @@ class TestStartCommand(unittest.TestCase):
                     "num_threads",
                     "timeout",
                     "persist_updates",
+                    "rebuild_index_strategy",
                     "only_pso_and_pos_permutations",
                     "use_patterns",
                     "use_text_index",


### PR DESCRIPTION
Companion to ad-freiburg/qlever#3163, which adds automatic index rebuilds to `qlever-server`, controlled by the new option `--rebuild-index-strategy`.

With this change, `qlever start` accepts the option (also settable via `REBUILD_INDEX_STRATEGY` in the `[server]` section of the `Qleverfile`) and forwards it to the server: `manual` (the default) or `automatic:min:max:fraction`, where a rebuild is triggered automatically in the background once the number of delta triples reaches the given `fraction` of the number of index triples, but never below `min` and always at `max` (e.g. `10000:1000000:0.1`).

For the default value `manual`, the flag is not passed to the server at all, so that older server binaries without the option keep working.