### PR TITLE
Add `--rebuild-keep-previous-index-dirs` to `qlever start`

### DIFF
--- a/src/qlever/commands/rebuild_index.py
+++ b/src/qlever/commands/rebuild_index.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
 import json
-import shutil
 import subprocess
 import time
-from pathlib import Path
-
-from termcolor import colored
 
 from qlever.command import QleverCommand
 from qlever.log import log
@@ -53,25 +49,6 @@ class RebuildIndexCommand(QleverCommand):
             default=False,
             help="After the rebuild, send a simple test query to the server "
             "and report whether it succeeds",
-        )
-        subparser.add_argument(
-            "--keep-previous-index-dirs",
-            choices=[
-                "all",
-                "none",
-                "original-only",
-                "most-recent-only",
-                "original-and-most-recent",
-            ],
-            default="original-and-most-recent",
-            help="Which `previous.*` index directories to keep after a "
-            "successful rebuild: "
-            "all (keep all), "
-            "none (delete all), "
-            "original-only (keep only the very first), "
-            "most-recent-only (keep only the most recently created), "
-            "original-and-most-recent (keep both) "
-            "(default: original-and-most-recent)",
         )
 
     def execute(self, args) -> bool:
@@ -175,49 +152,5 @@ class RebuildIndexCommand(QleverCommand):
             else:
                 log.error("Test query failed")
                 return False
-
-        # Clean up previous index directories according to
-        # `--keep-previous-index-dirs`. Find all subdirectories starting with
-        # `previous.`, ordered from oldest to newest (by creation time), and
-        # keep or delete them according to the specified policy.
-        if args.keep_previous_index_dirs != "all":
-            previous_index_dirs = sorted(
-                [
-                    dir
-                    for dir in Path(".").iterdir()
-                    if dir.is_dir() and dir.name.startswith("previous.")
-                ],
-                key=lambda dir: dir.stat().st_ctime,
-            )
-            policy = args.keep_previous_index_dirs
-            log.info("")
-            log.info(
-                colored(
-                    f"Iterate over previous index directories (oldest"
-                    f" to newest), and check which ones to keep or"
-                    f" delete (keep_previous_index_dirs = {policy}):",
-                    color="blue",
-                )
-            )
-            log.info("")
-            for i, dir in enumerate(previous_index_dirs):
-                is_original = i == 0
-                is_most_recent = i == len(previous_index_dirs) - 1
-                if policy == "none":
-                    action = "DELETE"
-                elif policy == "original-only":
-                    action = "KEEP" if is_original else "DELETE"
-                elif policy == "most-recent-only":
-                    action = "KEEP" if is_most_recent else "DELETE"
-                elif policy == "original-and-most-recent":
-                    action = (
-                        "KEEP" if is_original or is_most_recent else "DELETE"
-                    )
-                log.info(f"{dir.name}  ->  {action}")
-                if action == "DELETE":
-                    try:
-                        shutil.rmtree(dir)
-                    except Exception as e:
-                        log.error(f"Failed to delete {dir.name}: {e}")
 
         return True

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -40,10 +40,15 @@ def construct_command(args) -> str:
         start_cmd += f" -a {args.access_token}"
     if args.persist_updates:
         start_cmd += " --persist-updates"
-    # Only pass the flag for a non-default value, so that older server
-    # binaries without this option keep working.
+    # Only pass the flags for non-default values, so that older server
+    # binaries without these options keep working.
     if args.rebuild_index_strategy != "manual":
         start_cmd += f" --rebuild-index-strategy {args.rebuild_index_strategy}"
+    if args.rebuild_keep_previous_index_dirs != "original-and-most-recent":
+        start_cmd += (
+            f" --rebuild-keep-previous-index-dirs"
+            f" {args.rebuild_keep_previous_index_dirs}"
+        )
     if args.only_pso_and_pos_permutations:
         start_cmd += " --only-pso-and-pos-permutations"
     if args.use_patterns == "no":
@@ -171,6 +176,7 @@ class StartCommand(QleverCommand):
                 "timeout",
                 "persist_updates",
                 "rebuild_index_strategy",
+                "rebuild_keep_previous_index_dirs",
                 "only_pso_and_pos_permutations",
                 "use_patterns",
                 "use_text_index",

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -39,25 +39,36 @@ class Qleverfile:
     SERVER_RUNTIME_PARAMETERS = [
         "cache-max-num-entries",
         "cache-max-size",
+        "cache-max-size-lazy-result",
         "cache-max-size-single-entry",
         "cache-service-results",
+        "construct-deduplication",
         "default-query-timeout",
         "disable-caching",
         "division-by-zero-is-undef",
         "enable-distributive-union",
+        "enable-materialized-view-query-rewrite",
         "enable-prefilter-on-index-scans",
         "group-by-disable-index-scan-optimizations",
         "group-by-hash-map-enabled",
         "lazy-index-scan-max-size-materialization",
         "lazy-index-scan-num-threads",
         "lazy-index-scan-queue-size",
-        "lazy-result-max-cache-size",
+        "log-level",
+        "materialized-view-writer-memory",
+        "parallel-sort-num-threads",
+        "pattern-trick-num-threads",
         "permutation-writer-num-threads",
+        "prefiltered-optional-join",
         "query-planning-budget",
+        "rebuild-index-scan-num-threads",
+        "rebuild-max-concurrent-permutation-pairs",
+        "rebuild-permutation-writer-num-threads",
         "request-body-limit",
         "service-allowed-iri-prefixes",
         "service-max-redirects",
         "service-max-value-rows",
+        "small-index-scan-size-estimate-divisor",
         "sort-estimate-cancellation-factor",
         "sort-in-memory-threshold",
         "sparql-results-json-with-time",
@@ -68,7 +79,9 @@ class Qleverfile:
         "throw-on-unbound-variables",
         "treat-default-graph-as-named-graph",
         "use-binsearch-transitive-path",
+        "vacuum-minimum-block-size",
         "websocket-updates-enabled",
+        "zero-cost-estimate-for-cached-subtree",
     ]
 
     @staticmethod
@@ -371,6 +384,25 @@ class Qleverfile:
             "triples reaches the given `fraction` of the number of index "
             "triples, but never below `min` and always at `max`, "
             'e.g. "automatic:10000:1000000:0.1")',
+        )
+        server_args["rebuild_keep_previous_index_dirs"] = arg(
+            "--rebuild-keep-previous-index-dirs",
+            choices=[
+                "all",
+                "none",
+                "original-only",
+                "most-recent-only",
+                "original-and-most-recent",
+            ],
+            default="original-and-most-recent",
+            help="Which `previous.*` index directories the server keeps after "
+            "a successful index rebuild, manual or automatic (each rebuild "
+            "moves the index that was served so far into such a directory): "
+            "all (keep all), "
+            "none (delete all), "
+            "original-only (keep only the very first), "
+            "most-recent-only (keep only the most recently created), "
+            "original-and-most-recent (keep both)",
         )
         server_args["only_pso_and_pos_permutations"] = arg(
             "--only-pso-and-pos-permutations",

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -21,6 +21,7 @@ def test_construct_command_with_if():
     args.timeout = True
     args.persist_updates = False
     args.rebuild_index_strategy = "automatic:10000:1000000:0.1"
+    args.rebuild_keep_previous_index_dirs = "most-recent-only"
     args.access_token = True
     args.only_pso_and_pos_permutations = True
     args.use_patterns = "no"
@@ -44,6 +45,7 @@ def test_construct_command_with_if():
         f" -s {args.timeout}"
         f" -a {args.access_token}"
         " --rebuild-index-strategy automatic:10000:1000000:0.1"
+        " --rebuild-keep-previous-index-dirs most-recent-only"
         " --only-pso-and-pos-permutations"
         " --no-patterns"
         " -t"
@@ -69,6 +71,7 @@ def test_construct_command_without_if():
     args.timeout = False
     args.persist_updates = False
     args.rebuild_index_strategy = "manual"
+    args.rebuild_keep_previous_index_dirs = "original-and-most-recent"
     args.access_token = False
     args.only_pso_and_pos_permutations = False
     args.use_patterns = True
@@ -372,6 +375,7 @@ class TestStartCommand(unittest.TestCase):
         args.timeout = True
         args.persist_updates = False
         args.rebuild_index_strategy = "manual"
+        args.rebuild_keep_previous_index_dirs = "original-and-most-recent"
         args.access_token = True
         args.only_pso_and_pos_permutations = True
         args.use_patterns = "no"

--- a/test/qlever/commands/test_start_other_methods.py
+++ b/test/qlever/commands/test_start_other_methods.py
@@ -41,6 +41,7 @@ class TestStartCommand(unittest.TestCase):
                     "timeout",
                     "persist_updates",
                     "rebuild_index_strategy",
+                    "rebuild_keep_previous_index_dirs",
                     "only_pso_and_pos_permutations",
                     "use_patterns",
                     "use_text_index",


### PR DESCRIPTION
Since ad-freiburg/qlever#3187, `qlever-server` cleans up the `previous.*` index directories itself after every index rebuild, manual or automatic, according to its option `--rebuild-keep-previous-index-dirs`. With this change, that option can be set via `qlever start` and via `REBUILD_KEEP_PREVIOUS_INDEX_DIRS` in the `[server]` section of the Qleverfile. It is only passed to `qlever-server` for a non-default value, so that older server binaries keep working.

The now redundant client-side cleanup of `qlever rebuild-index` (option `--keep-previous-index-dirs`) is removed. The server has already applied its policy when the `cmd=rebuild-index` request returns. A client-side pass after that could only fight the server's policy, and it could race with the cleanup of a concurrent automatic rebuild.

On the side, update the list of runtime parameters used for tab completion of `qlever settings` and `qlever start`. It was missing 14 parameters that current `qlever-server` binaries have (among them the three `rebuild-*` parameters) and still contained `lazy-result-max-cache-size`, which is now called `cache-max-size-lazy-result`.