### PR TITLE
Add option `--set-runtime-parameters` to `qlever start`

### DIFF
--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -49,6 +49,14 @@ def construct_command(args) -> str:
             f" --rebuild-keep-previous-index-dirs"
             f" {args.rebuild_keep_previous_index_dirs}"
         )
+    # One `--set-runtime-parameter` per assignment (the option is not
+    # multitoken).
+    set_runtime_parameters = vars(args).get("set_runtime_parameters")
+    if set_runtime_parameters:
+        start_cmd += "".join(
+            f" --set-runtime-parameter {shlex.quote(assignment)}"
+            for assignment in set_runtime_parameters
+        )
     if args.only_pso_and_pos_permutations:
         start_cmd += " --only-pso-and-pos-permutations"
     if args.use_patterns == "no":
@@ -177,6 +185,7 @@ class StartCommand(QleverCommand):
                 "persist_updates",
                 "rebuild_index_strategy",
                 "rebuild_keep_previous_index_dirs",
+                "set_runtime_parameters",
                 "only_pso_and_pos_permutations",
                 "use_patterns",
                 "use_text_index",

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -49,9 +49,15 @@ def construct_command(args) -> str:
             f" --rebuild-keep-previous-index-dirs"
             f" {args.rebuild_keep_previous_index_dirs}"
         )
-    # One `--set-runtime-parameter` per assignment (the option is not
-    # multitoken).
-    set_runtime_parameters = vars(args).get("set_runtime_parameters")
+    # Merge the runtime parameters from the Qleverfile with those from the
+    # command line. The command line takes precedence per parameter name, so
+    # specifying one parameter on the command line does not silently drop
+    # the other parameters from the Qleverfile. One `--set-runtime-parameter`
+    # per assignment (the option is not multitoken).
+    set_runtime_parameters = merge_runtime_parameters(
+        get_runtime_parameters_from_qleverfile(args),
+        vars(args).get("set_runtime_parameters") or [],
+    )
     if set_runtime_parameters:
         start_cmd += "".join(
             f" --set-runtime-parameter {shlex.quote(assignment)}"
@@ -149,6 +155,41 @@ def set_text_description(access_arg, port, text_desc) -> bool:
         log.error(f"Setting the text description failed ({e})")
         return False
     return True
+
+
+def get_runtime_parameters_from_qleverfile(args) -> list[str]:
+    """
+    Return the value of `SET_RUNTIME_PARAMETERS` from the Qleverfile as a
+    list of `name=value` assignments, or an empty list if there is no
+    Qleverfile or no such option.
+    """
+    try:
+        qleverfile_path = Path(vars(args).get("qleverfile", "Qleverfile"))
+        if not qleverfile_path.is_file():
+            return []
+        config = Qleverfile.read(qleverfile_path)
+        value = config.get("server", "set_runtime_parameters", fallback=None)
+        return shlex.split(value) if value else []
+    except Exception:
+        return []
+
+
+def merge_runtime_parameters(
+    from_qleverfile: list[str], from_command_line: list[str]
+) -> list[str]:
+    """
+    Merge two lists of `name=value` assignments. Assignments from the
+    command line take precedence over assignments for the same name from
+    the Qleverfile. The order is that of the Qleverfile, with additional
+    names from the command line appended.
+    """
+    merged = {
+        assignment.split("=", 1)[0]: assignment
+        for assignment in from_qleverfile
+    }
+    for assignment in from_command_line:
+        merged[assignment.split("=", 1)[0]] = assignment
+    return list(merged.values())
 
 
 class StartCommand(QleverCommand):

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -413,7 +413,9 @@ class Qleverfile:
             "server startup, each in the form `name=value` (for the list of "
             "runtime parameters and their default values, run "
             "`qlever-server --set-runtime-parameter help`; they can also be "
-            "changed while the server is running, via `qlever settings`)",
+            "changed while the server is running, via `qlever settings`); "
+            "parameters given on the command line are merged with those "
+            "from the Qleverfile and take precedence for the same name",
         )
         server_args["only_pso_and_pos_permutations"] = arg(
             "--only-pso-and-pos-permutations",

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -404,6 +404,17 @@ class Qleverfile:
             "most-recent-only (keep only the most recently created), "
             "original-and-most-recent (keep both)",
         )
+        server_args["set_runtime_parameters"] = arg(
+            "--set-runtime-parameters",
+            nargs="+",
+            default=None,
+            metavar="NAME=VALUE",
+            help="Space-separated list of runtime parameters to set at "
+            "server startup, each in the form `name=value` (for the list of "
+            "runtime parameters and their default values, run "
+            "`qlever-server --set-runtime-parameter help`; they can also be "
+            "changed while the server is running, via `qlever settings`)",
+        )
         server_args["only_pso_and_pos_permutations"] = arg(
             "--only-pso-and-pos-permutations",
             action="store_true",

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -22,6 +22,10 @@ def test_construct_command_with_if():
     args.persist_updates = False
     args.rebuild_index_strategy = "automatic:10000:1000000:0.1"
     args.rebuild_keep_previous_index_dirs = "most-recent-only"
+    args.set_runtime_parameters = [
+        "default-query-timeout=300s",
+        "rebuild-max-concurrent-permutation-pairs=1",
+    ]
     args.access_token = True
     args.only_pso_and_pos_permutations = True
     args.use_patterns = "no"
@@ -46,6 +50,8 @@ def test_construct_command_with_if():
         f" -a {args.access_token}"
         " --rebuild-index-strategy automatic:10000:1000000:0.1"
         " --rebuild-keep-previous-index-dirs most-recent-only"
+        " --set-runtime-parameter default-query-timeout=300s"
+        " --set-runtime-parameter rebuild-max-concurrent-permutation-pairs=1"
         " --only-pso-and-pos-permutations"
         " --no-patterns"
         " -t"
@@ -72,6 +78,7 @@ def test_construct_command_without_if():
     args.persist_updates = False
     args.rebuild_index_strategy = "manual"
     args.rebuild_keep_previous_index_dirs = "original-and-most-recent"
+    args.set_runtime_parameters = None
     args.access_token = False
     args.only_pso_and_pos_permutations = False
     args.use_patterns = True

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -752,3 +752,55 @@ class TestStartCommand(unittest.TestCase):
 
         # Execute the function and check if return is False
         self.assertTrue(StartCommand().execute(args))
+
+
+class TestMergeRuntimeParameters(unittest.TestCase):
+    def test_command_line_takes_precedence_per_name(self):
+        from qlever.commands.start import merge_runtime_parameters
+
+        self.assertEqual(
+            merge_runtime_parameters(
+                ["a=1", "b=2"],
+                ["b=3", "c=4"],
+            ),
+            ["a=1", "b=3", "c=4"],
+        )
+
+    def test_empty_lists(self):
+        from qlever.commands.start import merge_runtime_parameters
+
+        self.assertEqual(merge_runtime_parameters([], []), [])
+        self.assertEqual(merge_runtime_parameters(["a=1"], []), ["a=1"])
+        self.assertEqual(merge_runtime_parameters([], ["a=1"]), ["a=1"])
+
+    def test_qleverfile_parameters_are_read_and_merged(self):
+        import tempfile
+        from types import SimpleNamespace
+
+        from qlever.commands.start import (
+            get_runtime_parameters_from_qleverfile,
+        )
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".qleverfile"
+        ) as file:
+            file.write(
+                "[data]\nNAME = test\n\n[server]\n"
+                "SET_RUNTIME_PARAMETERS = a=1 b=2\n"
+            )
+            file.flush()
+            args = SimpleNamespace(qleverfile=file.name)
+            self.assertEqual(
+                get_runtime_parameters_from_qleverfile(args),
+                ["a=1", "b=2"],
+            )
+
+    def test_no_qleverfile_yields_empty_list(self):
+        from types import SimpleNamespace
+
+        from qlever.commands.start import (
+            get_runtime_parameters_from_qleverfile,
+        )
+
+        args = SimpleNamespace(qleverfile="/nonexistent/Qleverfile")
+        self.assertEqual(get_runtime_parameters_from_qleverfile(args), [])

--- a/test/qlever/commands/test_start_other_methods.py
+++ b/test/qlever/commands/test_start_other_methods.py
@@ -42,6 +42,7 @@ class TestStartCommand(unittest.TestCase):
                     "persist_updates",
                     "rebuild_index_strategy",
                     "rebuild_keep_previous_index_dirs",
+                    "set_runtime_parameters",
                     "only_pso_and_pos_permutations",
                     "use_patterns",
                     "use_text_index",


### PR DESCRIPTION
Companion to ad-freiburg/qlever#3132, which added the repeatable option `--set-runtime-parameter name=value` to `qlever-server` for setting any runtime parameter at startup.

With this change, `qlever start` accepts the option in the plural form `--set-runtime-parameters` (as a space-separated list of `name=value` assignments) and adds it to the `qlever-server` command line with one `--set-runtime-parameter` per assignment. It is also settable via `SET_RUNTIME_PARAMETERS` in the `[server]` section of the `Qleverfile`. When the option is not given, the command line is unchanged, so that older `qlever-server` binaries without the option keep working.

When runtime parameters are specified both in the Qleverfile and on the command line, the two lists are merged per parameter name, and the command line takes precedence for the same name. In particular, specifying one or more parameters on the command line does not drop the parameters from the Qleverfile.

NOTE: This is more robust than applying the parameters via `qlever settings` after the start. With the new option, the parameters are already in effect when the server answers its first request, and they are set again automatically on every restart. They can still be changed while the server is running.