### PR TITLE
Use Python instead of `sed` to edit the `Qleverfile` in `setup-config`

### DIFF
--- a/src/qlever/commands/setup_config.py
+++ b/src/qlever/commands/setup_config.py
@@ -64,11 +64,15 @@ class SetupConfigCommand(QleverCommand):
         )
         # Override defaults to None so that arguments explicitly passed
         # by the user can be told apart from plain defaults.
+        #
+        # NOTE: This relies on `additional_arguments` being called after
+        # the Qleverfile arguments were added, because in `argparse` the
+        # default set last wins.
         for section, arg_name in self.override_args:
             subparser.set_defaults(**{arg_name: None})
 
     def execute(self, args) -> bool:
-        # Show a warning if `QLEVER_OVERRIDE_SYSTEM_NATIVE` is set.
+        # Show a warning if `QLEVER_IS_RUNNING_IN_CONTAINER` is set.
         qlever_is_running_in_container = environ.get(
             "QLEVER_IS_RUNNING_IN_CONTAINER"
         )
@@ -126,9 +130,10 @@ class SetupConfigCommand(QleverCommand):
         # applied.
         try:
             lines = qleverfile_path.read_text().splitlines()
-            result = util.update_ini_values(
-                lines, updates, inline_comment_prefix="#"
-            )
+            # No `inline_comment_prefix`, because `Qleverfile.read`
+            # parses without inline comments (a `#` after a value is
+            # part of the value).
+            result = util.update_ini_values(lines, updates)
             Path("Qleverfile").write_text("\n".join(result) + "\n")
         except Exception as e:
             log.error(

--- a/src/qlever/commands/setup_config.py
+++ b/src/qlever/commands/setup_config.py
@@ -1,12 +1,25 @@
 from __future__ import annotations
 
-import subprocess
 from os import environ
 from pathlib import Path
 
 import qlever.util as util
 from qlever.command import QleverCommand
 from qlever.log import log
+
+
+def check_qleverfile_exists() -> bool:
+    """Return True if a Qleverfile already exists (and log an error)."""
+    if Path("Qleverfile").exists():
+        log.error("`Qleverfile` already exists in current directory")
+        log.info("")
+        log.info(
+            "If you want to create a new Qleverfile using "
+            "`qlever setup-config`, delete the existing Qleverfile "
+            "first"
+        )
+        return True
+    return False
 
 
 class SetupConfigCommand(QleverCommand):
@@ -49,19 +62,10 @@ class SetupConfigCommand(QleverCommand):
             choices=self.qleverfile_names,
             help="The name of the pre-configured Qleverfile to create",
         )
-
-    def check_qleverfile_exists(self) -> bool:
-        """Return True if a Qleverfile already exists (and log an error)."""
-        if Path("Qleverfile").exists():
-            log.error("`Qleverfile` already exists in current directory")
-            log.info("")
-            log.info(
-                "If you want to create a new Qleverfile using "
-                "`qlever setup-config`, delete the existing Qleverfile "
-                "first"
-            )
-            return True
-        return False
+        # Override defaults to None so that arguments explicitly passed
+        # by the user can be told apart from plain defaults.
+        for section, arg_name in self.override_args:
+            subparser.set_defaults(**{arg_name: None})
 
     def execute(self, args) -> bool:
         # Show a warning if `QLEVER_OVERRIDE_SYSTEM_NATIVE` is set.
@@ -75,37 +79,57 @@ class SetupConfigCommand(QleverCommand):
                 "(since inside the container, QLever should run natively)"
             )
             log.info("")
-        # Construct the command line and show it.
+        # Build the updates for the copied Qleverfile.
         qleverfile_path = (
             self.qleverfiles_path / f"Qleverfile.{args.config_name}"
         )
-        setup_config_cmd = f"cat {qleverfile_path} | {util.get_ini_sed_cmd('server', 'ACCESS_TOKEN', util.get_random_string(12), True)}"
+        updates = {
+            "server": {
+                "ACCESS_TOKEN": (util.get_random_string(12), True),
+            },
+        }
+        for section, arg_name in self.override_args:
+            if arg_value := getattr(args, arg_name, None):
+                updates.setdefault(section, {})[arg_name.upper()] = (
+                    str(arg_value),
+                    False,
+                )
+        # Written last, so that it wins over an explicit `--system`.
         if qlever_is_running_in_container:
-            setup_config_cmd += (
-                f" | {util.get_ini_sed_cmd('runtime', 'SYSTEM', 'native')}"
-            )
-        else:
-            for section, arg_name in self.override_args:
-                if arg_value := getattr(args, arg_name, None):
-                    setup_config_cmd += f" | {util.get_ini_sed_cmd(section, arg_name.upper(), arg_value)}"
+            if args.system is not None and args.system != "native":
+                log.warning(
+                    f"Ignoring `--system {args.system}` because "
+                    "`QLEVER_IS_RUNNING_IN_CONTAINER` is set"
+                )
+                log.info("")
+            updates.setdefault("runtime", {})["SYSTEM"] = ("native", False)
 
-        setup_config_cmd += "> Qleverfile"
-        self.show(setup_config_cmd, only_show=args.show)
+        # Show the changes that will be applied to the copied template.
+        show_lines = [
+            f"Copy {qleverfile_path} to Qleverfile with the following changes:"
+        ]
+        for section, option_dict in updates.items():
+            show_lines.append(f"\n[{section}]")
+            for option, (value, is_suffix) in option_dict.items():
+                shown_value = (
+                    "*" * len(value) if option == "ACCESS_TOKEN" else value
+                )
+                show_lines.append(f"{option} = {shown_value}")
+        self.show("\n".join(show_lines), only_show=args.show)
         if args.show:
             return True
 
-        if self.check_qleverfile_exists():
+        if check_qleverfile_exists():
             return False
 
-        # Copy the Qleverfile to the current directory.
+        # Copy the Qleverfile to the current directory, with the updates
+        # applied.
         try:
-            subprocess.run(
-                setup_config_cmd,
-                shell=True,
-                check=True,
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
+            lines = qleverfile_path.read_text().splitlines()
+            result = util.update_ini_values(
+                lines, updates, inline_comment_prefix="#"
             )
+            Path("Qleverfile").write_text("\n".join(result) + "\n")
         except Exception as e:
             log.error(
                 f'Could not copy "{qleverfile_path}" to current directory: {e}'

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -508,18 +508,127 @@ def get_container_image_id(system: str, image: str) -> str:
     return image_id
 
 
-def get_ini_sed_cmd(
-    section: str, option: str, new_value: str, is_suffix: bool = False
+def edit_option_line(
+    line: str,
+    new_value: str,
+    is_suffix: bool,
+    inline_comment_prefix: str | None,
 ) -> str:
     """
-    Generates a cross-platform sed command to update the value of a
-    key = value pair or append to one (by using is_suffix = True) in an INI file.
+    Return `line` with its value replaced by `new_value`, or with
+    `new_value` appended to it if `is_suffix` is true. An inline comment
+    after the value is kept.
     """
+    # Split off an inline comment (whitespace followed by the comment
+    # prefix) so that only the value part is edited.
+    value_part = line
+    comment_part = ""
+    if inline_comment_prefix is not None:
+        comment_match = re.search(
+            rf"\s{re.escape(inline_comment_prefix)}", line
+        )
+        if comment_match:
+            value_part = line[: comment_match.start()]
+            comment_part = "\t" + line[comment_match.start() :].strip()
+
     if is_suffix:
-        pattern = f"s/(^{option}.*)/\\1{new_value}/"
+        new_line = value_part.rstrip() + new_value
     else:
-        pattern = f"s/(^{option}[[:space:]]*=[[:space:]]*).*/\\1{new_value}/"
-    return f"sed -E '/^\\[{section}\\]/,/^\\[/ {pattern}'"
+        # Keep everything up to and including the `=` and the spacing
+        # after it, replace the old value.
+        prefix_end = re.match(r"^\s*\S+\s*=\s*", value_part).end()
+        new_line = value_part[:prefix_end] + new_value
+    return new_line + comment_part
+
+
+def update_ini_values(
+    lines: list[str],
+    updates: dict[str, dict[str, tuple[str, bool]]],
+    inline_comment_prefix: str | None = None,
+) -> list[str]:
+    """
+    Update values in INI-style file content given as `lines` and return
+    the modified lines, preserving comments and unrelated lines.
+
+    `updates` maps `{section: {option: (new_value, is_suffix)}}`. An
+    existing option gets its value replaced, or `new_value` appended to
+    it if `is_suffix` is true. A missing option is added at the end of
+    its section, a missing section at the end of the file (suffix
+    entries are skipped there, they have no value to append to).
+
+    `inline_comment_prefix` is what starts a comment after a value on
+    the same line. If None, the whole line is treated as the value.
+    """
+    options_applied = {section: set() for section in updates}
+    sections_seen = set()
+    result_lines = []
+    current_section = None
+
+    def missing_option_lines(section: str) -> list[str]:
+        """
+        Lines for options of `section` that were not found in the file.
+        """
+        return [
+            f"{option} = {value}"
+            for option, (value, is_suffix) in updates[section].items()
+            if option not in options_applied[section] and not is_suffix
+        ]
+
+    def flush_missing_options(section: str):
+        """
+        Insert options of `section` that were not found in the file,
+        before any blank lines that separate it from the next section.
+        """
+        insert_at = len(result_lines)
+        while insert_at > 0 and result_lines[insert_at - 1].strip() == "":
+            insert_at -= 1
+        result_lines[insert_at:insert_at] = missing_option_lines(section)
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Section headers like `[server]`. Commented-out headers like
+        # `;[server]` do not match because of the `^` anchor.
+        header_match = re.match(r"^\[([^\]]+)\]", stripped)
+        if header_match:
+            # Add options that were missing from the section we leave.
+            if current_section in updates:
+                flush_missing_options(current_section)
+            current_section = header_match.group(1)
+            sections_seen.add(current_section)
+            result_lines.append(line)
+            continue
+
+        if current_section not in updates:
+            result_lines.append(line)
+            continue
+
+        option_match = re.match(r"^(\S+)\s*=\s*", stripped)
+        if (
+            option_match is None
+            or option_match.group(1) not in updates[current_section]
+        ):
+            result_lines.append(line)
+            continue
+
+        option_name = option_match.group(1)
+        new_value, is_suffix = updates[current_section][option_name]
+        result_lines.append(
+            edit_option_line(line, new_value, is_suffix, inline_comment_prefix)
+        )
+        options_applied[current_section].add(option_name)
+
+    # Add options missing from the last section in the file.
+    if current_section in updates:
+        flush_missing_options(current_section)
+
+    # Add sections that were not in the file at all.
+    for section in updates:
+        if section not in sections_seen:
+            result_lines.append(f"\n[{section}]")
+            result_lines.extend(missing_option_lines(section))
+
+    return result_lines
 
 
 def parse_memory(value: str) -> str:

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -557,7 +557,9 @@ def edit_option_line(
     else:
         # Keep everything up to and including the `=` and the spacing
         # after it, replace the old value.
-        prefix_end = re.match(r"^\s*\S+\s*=\s*", value_part).end()
+        # The non-greedy `\S+?` splits at the first `=`, like
+        # `ConfigParser` does.
+        prefix_end = re.match(r"^\s*\S+?\s*=\s*", value_part).end()
         new_line = value_part[:prefix_end] + new_value
     return new_line + comment_part
 
@@ -574,8 +576,9 @@ def update_ini_values(
     `updates` maps `{section: {option: (new_value, is_suffix)}}`. An
     existing option gets its value replaced, or `new_value` appended to
     it if `is_suffix` is true. A missing option is added at the end of
-    its section, a missing section at the end of the file (suffix
-    entries are skipped there, they have no value to append to).
+    its section, aligned with the section's existing options, a missing
+    section at the end of the file (suffix entries are skipped there,
+    they have no value to append to).
 
     `inline_comment_prefix` is what starts a comment after a value on
     the same line. If None, the whole line is treated as the value.
@@ -584,13 +587,23 @@ def update_ini_values(
     sections_seen = set()
     result_lines = []
     current_section = None
+    # Per section, the column of the `=` of the last option line seen,
+    # so that added options can be aligned with the existing ones.
+    equals_columns = {}
 
     def missing_option_lines(section: str) -> list[str]:
         """
         Lines for options of `section` that were not found in the file.
         """
+        column = equals_columns.get(section)
+
+        def option_line(option: str, value: str) -> str:
+            if column is not None and len(option) < column:
+                return f"{option.ljust(column)}= {value}"
+            return f"{option} = {value}"
+
         return [
-            f"{option} = {value}"
+            option_line(option, value)
             for option, (value, is_suffix) in updates[section].items()
             if option not in options_applied[section] and not is_suffix
         ]
@@ -624,7 +637,13 @@ def update_ini_values(
             result_lines.append(line)
             continue
 
-        option_match = re.match(r"^(\S+)\s*=\s*", stripped)
+        # The non-greedy `\S+?` splits at the first `=`, like
+        # `ConfigParser` does.
+        option_match = re.match(r"^(\S+?)\s*=\s*", stripped)
+        if option_match:
+            equals_columns[current_section] = (
+                re.match(r"^\s*\S+?\s*=", line).end() - 1
+            )
         if (
             option_match is None
             or option_match.group(1) not in updates[current_section]
@@ -643,10 +662,12 @@ def update_ini_values(
     if current_section in updates:
         flush_missing_options(current_section)
 
-    # Add sections that were not in the file at all.
+    # Add sections that were not in the file at all, each preceded by a
+    # blank line.
     for section in updates:
         if section not in sections_seen:
-            result_lines.append(f"\n[{section}]")
+            result_lines.append("")
+            result_lines.append(f"[{section}]")
             result_lines.extend(missing_option_lines(section))
 
     return result_lines

--- a/test/qlever/test_util.py
+++ b/test/qlever/test_util.py
@@ -4,9 +4,11 @@ import pytest
 
 from qlever.util import (
     container_memory_to_bytes,
+    edit_option_line,
     get_random_string,
     parse_git_hash,
     positive_int,
+    update_ini_values,
 )
 
 
@@ -87,3 +89,172 @@ def test_parse_git_hash_empty_file(tmp_path):
     path = tmp_path / "empty.txt"
     path.write_text("")
     assert parse_git_hash(path) is None
+
+
+def test_edit_option_line_replaces_value_and_keeps_alignment():
+    line = "PORT               = 7019"
+    assert (
+        edit_option_line(line, "9999", False, "#")
+        == "PORT               = 9999"
+    )
+
+
+def test_edit_option_line_appends_suffix():
+    line = "ACCESS_TOKEN       = ${data:NAME}"
+    assert (
+        edit_option_line(line, "abc", True, "#")
+        == "ACCESS_TOKEN       = ${data:NAME}abc"
+    )
+
+
+def test_edit_option_line_keeps_inline_comment():
+    line = "PORT               = 7019   # the port"
+    assert (
+        edit_option_line(line, "9999", False, "#")
+        == "PORT               = 9999\t# the port"
+    )
+    assert (
+        edit_option_line(line, "0", True, "#")
+        == "PORT               = 70190\t# the port"
+    )
+
+
+def test_edit_option_line_ignores_comment_char_inside_value():
+    # No whitespace before the `#`, so it is part of the value.
+    line = "ENCODE_AS_ID = https://example.org/geom#osmnode_"
+    assert (
+        edit_option_line(line, "X", True, "#")
+        == "ENCODE_AS_ID = https://example.org/geom#osmnode_X"
+    )
+
+
+def test_edit_option_line_without_comment_prefix():
+    # Without a prefix the comment is part of the value, so a suffix
+    # lands after it.
+    line = "PORT = 7019 # the port"
+    assert edit_option_line(line, "0", True, None) == "PORT = 7019 # the port0"
+
+
+def test_update_ini_values_replaces_and_appends():
+    lines = [
+        "[server]",
+        "PORT               = 7019",
+        "ACCESS_TOKEN       = ${data:NAME}",
+    ]
+    updates = {
+        "server": {
+            "PORT": ("9999", False),
+            "ACCESS_TOKEN": ("abc", True),
+        }
+    }
+    assert update_ini_values(lines, updates) == [
+        "[server]",
+        "PORT               = 9999",
+        "ACCESS_TOKEN       = ${data:NAME}abc",
+    ]
+
+
+def test_update_ini_values_passes_comment_prefix_on():
+    lines = ["[server]", "PORT = 7019  # the port"]
+    updates = {"server": {"PORT": ("9999", False)}}
+    assert update_ini_values(lines, updates, inline_comment_prefix="#") == [
+        "[server]",
+        "PORT = 9999\t# the port",
+    ]
+
+
+def test_update_ini_values_adds_option_missing_from_section():
+    lines = ["[server]", "PORT = 7019", "", "[runtime]", "SYSTEM = docker"]
+    updates = {"server": {"TIMEOUT": ("30s", False)}}
+    assert update_ini_values(lines, updates) == [
+        "[server]",
+        "PORT = 7019",
+        "TIMEOUT = 30s",
+        "",
+        "[runtime]",
+        "SYSTEM = docker",
+    ]
+
+
+def test_update_ini_values_adds_option_to_last_section():
+    lines = ["[server]", "PORT = 7019"]
+    updates = {"server": {"TIMEOUT": ("30s", False)}}
+    assert update_ini_values(lines, updates) == [
+        "[server]",
+        "PORT = 7019",
+        "TIMEOUT = 30s",
+    ]
+
+
+def test_update_ini_values_adds_missing_section():
+    lines = ["[server]", "PORT = 7019"]
+    updates = {"runtime": {"SYSTEM": ("native", False)}}
+    assert update_ini_values(lines, updates) == [
+        "[server]",
+        "PORT = 7019",
+        "\n[runtime]",
+        "SYSTEM = native",
+    ]
+
+
+def test_update_ini_values_skips_suffix_in_missing_section():
+    # A suffix entry has no value to append to, so it is not added.
+    lines = ["[server]", "PORT = 7019"]
+    updates = {
+        "runtime": {
+            "SYSTEM": ("native", False),
+            "EXTRA": ("abc", True),
+        }
+    }
+    assert update_ini_values(lines, updates) == [
+        "[server]",
+        "PORT = 7019",
+        "\n[runtime]",
+        "SYSTEM = native",
+    ]
+
+
+def test_update_ini_values_ignores_commented_out_lines():
+    lines = ["[server]", ";PORT = 1111", "PORT = 7019"]
+    updates = {"server": {"PORT": ("9999", False)}}
+    assert update_ini_values(lines, updates) == [
+        "[server]",
+        ";PORT = 1111",
+        "PORT = 9999",
+    ]
+
+
+def test_update_ini_values_ignores_commented_out_section():
+    # `;[server]` is not a section, so `PORT` is not inside one and the
+    # section is added at the end instead.
+    lines = [";[server]", "PORT = 7019"]
+    updates = {"server": {"PORT": ("9999", False)}}
+    assert update_ini_values(lines, updates) == [
+        ";[server]",
+        "PORT = 7019",
+        "\n[server]",
+        "PORT = 9999",
+    ]
+
+
+def test_update_ini_values_leaves_other_sections_alone():
+    lines = ["[server]", "PORT = 7019", "[index]", "PORT = 1234"]
+    updates = {"server": {"PORT": ("9999", False)}}
+    assert update_ini_values(lines, updates) == [
+        "[server]",
+        "PORT = 9999",
+        "[index]",
+        "PORT = 1234",
+    ]
+
+
+def test_update_ini_values_keeps_unrelated_lines():
+    lines = ["# a comment", "", "[server]", "PORT = 7019", "HOST = localhost"]
+    updates = {"server": {"PORT": ("9999", False)}}
+    assert update_ini_values(lines, updates) == [
+        "# a comment",
+        "",
+        "[server]",
+        "PORT = 9999",
+        "HOST = localhost",
+    ]

--- a/test/qlever/test_util.py
+++ b/test/qlever/test_util.py
@@ -192,8 +192,19 @@ def test_update_ini_values_adds_missing_section():
     assert update_ini_values(lines, updates) == [
         "[server]",
         "PORT = 7019",
-        "\n[runtime]",
+        "",
+        "[runtime]",
         "SYSTEM = native",
+    ]
+
+
+def test_update_ini_values_aligns_added_option_with_section():
+    lines = ["[server]", "PORT               = 7019"]
+    updates = {"server": {"TIMEOUT": ("30s", False)}}
+    assert update_ini_values(lines, updates) == [
+        "[server]",
+        "PORT               = 7019",
+        "TIMEOUT            = 30s",
     ]
 
 
@@ -209,7 +220,8 @@ def test_update_ini_values_skips_suffix_in_missing_section():
     assert update_ini_values(lines, updates) == [
         "[server]",
         "PORT = 7019",
-        "\n[runtime]",
+        "",
+        "[runtime]",
         "SYSTEM = native",
     ]
 
@@ -232,7 +244,8 @@ def test_update_ini_values_ignores_commented_out_section():
     assert update_ini_values(lines, updates) == [
         ";[server]",
         "PORT = 7019",
-        "\n[server]",
+        "",
+        "[server]",
         "PORT = 9999",
     ]
 


### PR DESCRIPTION
`qlever setup-config` no longer pipes the template through `sed` to patch in the `ACCESS_TOKEN` and the `--port`, `--timeout`, and `--system` overrides, but edits it in Python with the new `util.update_ini_values`. That does not depend on the platform's `sed`, and unlike a `sed` substitution it can also add an option or a section that the template does not have.

`--show` now prints the options that will differ from the template, with the `ACCESS_TOKEN` masked, instead of a shell pipeline. With `QLEVER_IS_RUNNING_IN_CONTAINER` set, `--port` and `--timeout` are now still applied and only `SYSTEM` is forced to `native`; before, all overrides were skipped in that case. And an override that was not given on the command line is no longer written at all, so a generated Qleverfile keeps the `TIMEOUT` and `SYSTEM` of its template.