### PR TITLE
Allow reading query for `qlever materialized-view` from `Qleverfile`

### DIFF
--- a/src/qlever/commands/materialized_view.py
+++ b/src/qlever/commands/materialized_view.py
@@ -68,6 +68,12 @@ class MaterializedViewCommand(QleverCommand):
             help="Delete an existing materialized view instead of "
             "creating one",
         )
+        subparser.add_argument(
+            "--overwrite-existing",
+            action="store_true",
+            default=False,
+            help="Overwrite an existing materialized view with the same name",
+        )
 
     def execute(self, args) -> bool:
         # SPARQL endpoint to use.
@@ -212,6 +218,22 @@ class MaterializedViewCommand(QleverCommand):
         self.show(materialized_view_cmd, only_show=args.show)
         if args.show:
             return True
+
+        # Check if files of a materialized view with that name already exist
+        # (their names all start with `<name>.view.<view name>.`; since view
+        # names cannot contain dots, the glob matches only this view's files).
+        existing_view_files = sorted(
+            path.name
+            for path in Path.cwd().glob(f"{args.name}.view.{args.view_name}.*")
+        )
+        if len(existing_view_files) > 0 and not args.overwrite_existing:
+            log.error(
+                f"Materialized view '{args.view_name}' already exists, "
+                f"if you want to overwrite it, use --overwrite-existing"
+            )
+            log.info("")
+            log.info(f"Existing files: {existing_view_files}")
+            return False
 
         # Run the command (and time it).
         time_start = time.monotonic()

--- a/src/qlever/commands/materialized_view.py
+++ b/src/qlever/commands/materialized_view.py
@@ -4,9 +4,11 @@ import json
 import re
 import shlex
 import time
+from pathlib import Path
 
 from qlever.command import QleverCommand
 from qlever.log import log
+from qlever.qleverfile import Qleverfile
 from qlever.util import (
     run_command,
 )
@@ -158,12 +160,35 @@ class MaterializedViewCommand(QleverCommand):
             log.info(f"Materialized view '{view_name}' loaded")
             return True
 
+        # If no query was given, try to take it from MATERIALIZED_VIEWS in
+        # the Qleverfile (same key as used by `qlever index`). Read
+        # directly instead of via `relevant_qleverfile_arguments`, which
+        # would also add an (unwanted) `--materialized-views` option.
+        if args.view_query is None:
+            qleverfile_path = Path(getattr(args, "qleverfile", "Qleverfile"))
+            if qleverfile_path.is_file():
+                try:
+                    qleverfile_config = Qleverfile.read(qleverfile_path)
+                    materialized_views = json.loads(
+                        qleverfile_config.get(
+                            "index", "materialized_views", fallback="{}"
+                        )
+                    )
+                except Exception as e:
+                    log.error(
+                        "Failed to read MATERIALIZED_VIEWS from "
+                        f"`{qleverfile_path}`: {e}"
+                    )
+                    return False
+                args.view_query = materialized_views.get(args.view_name)
+
         # A query is required when creating a materialized view.
         if args.view_query is None:
             log.error(
-                "A query is required when creating a materialized view"
-                " (use --load to load an existing one, or --delete to"
-                " delete one)"
+                f"No query given for materialized view '{args.view_name}', "
+                "and none found for it in MATERIALIZED_VIEWS in the "
+                "Qleverfile (use --load to load an existing one, or "
+                "--delete to delete one)"
             )
             return False
 

--- a/src/qlever/commands/materialized_view.py
+++ b/src/qlever/commands/materialized_view.py
@@ -172,7 +172,8 @@ class MaterializedViewCommand(QleverCommand):
                     materialized_views = json.loads(
                         qleverfile_config.get(
                             "index", "materialized_views", fallback="{}"
-                        )
+                        ).strip()
+                        or "{}"
                     )
                 except Exception as e:
                     log.error(


### PR DESCRIPTION
If the user calls `qlever materialized-view NAME QUERY` without a `QUERY`, we now look if a view with name `NAME` is defined in the `Qleverfile` and if yes, use that query. This is useful for rewriting a view defined in the `Qleverfile`. In particular, fixes #315.

While at it, introduce an option `--overwrite-existing` and only overwrite an existing materialized view with the same name when that option is specified.