### PR TITLE
Add options `GEO_CELL_GRID_LEVEL` and `GEO_CELL_GRID_SCHEME` for `qlever index`

### DIFF
--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -77,6 +77,7 @@ class IndexCommand(QleverCommand):
             "index": [
                 "input_files",
                 "cat_input_files",
+                "geo_cell_grid_level",
                 "encode_as_id",
                 "multi_input_json",
                 "parallel_parsing",
@@ -290,6 +291,8 @@ class IndexCommand(QleverCommand):
             return False
 
         # Add remaining options.
+        if args.geo_cell_grid_level:
+            index_cmd += f" --geo-cell-grid-level {args.geo_cell_grid_level}"
         if args.encode_as_id:
             index_cmd += f" --encode-as-id {args.encode_as_id}"
         if args.only_pso_and_pos_permutations:

--- a/src/qlever/commands/index.py
+++ b/src/qlever/commands/index.py
@@ -78,6 +78,7 @@ class IndexCommand(QleverCommand):
                 "input_files",
                 "cat_input_files",
                 "geo_cell_grid_level",
+                "geo_cell_grid_scheme",
                 "encode_as_id",
                 "multi_input_json",
                 "parallel_parsing",
@@ -293,6 +294,8 @@ class IndexCommand(QleverCommand):
         # Add remaining options.
         if args.geo_cell_grid_level:
             index_cmd += f" --geo-cell-grid-level {args.geo_cell_grid_level}"
+        if args.geo_cell_grid_scheme:
+            index_cmd += f" --geo-cell-grid-scheme {args.geo_cell_grid_scheme}"
         if args.encode_as_id:
             index_cmd += f" --encode-as-id {args.encode_as_id}"
         if args.only_pso_and_pos_permutations:

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -233,8 +233,12 @@ class Qleverfile:
         index_args["geo_cell_grid_scheme"] = arg(
             "--geo-cell-grid-scheme",
             type=str,
-            choices=["flat", "flat-4-shifts", "hierarchical",
-                     "hierarchical-3-shifts"],
+            choices=[
+                "flat",
+                "flat-4-shifts",
+                "hierarchical",
+                "hierarchical-3-shifts",
+            ],
             default=None,
             help="Cell assignment scheme of the geo cell grid "
             "(default: flat); only relevant with GEO_CELL_GRID_LEVEL > 0",

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -230,6 +230,15 @@ class Qleverfile:
             "geo cell prefilter for spatial joins; requires VOCABULARY_TYPE "
             "on-disk-compressed-geo-split (default: no grid)",
         )
+        index_args["geo_cell_grid_scheme"] = arg(
+            "--geo-cell-grid-scheme",
+            type=str,
+            choices=["flat", "flat-4-shifts", "hierarchical",
+                     "hierarchical-3-shifts"],
+            default=None,
+            help="Cell assignment scheme of the geo cell grid "
+            "(default: flat); only relevant with GEO_CELL_GRID_LEVEL > 0",
+        )
         index_args["encode_as_id"] = arg(
             "--encode-as-id",
             type=str,

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -221,6 +221,15 @@ class Qleverfile:
             "large enough to contain the end of at least one statement "
             "(default: 10M)",
         )
+        index_args["geo_cell_grid_level"] = arg(
+            "--geo-cell-grid-level",
+            type=int,
+            default=None,
+            help="Level L of the geo cell grid for WKT literals: the grid "
+            "cell of each literal is encoded into its ID, which enables the "
+            "geo cell prefilter for spatial joins; requires VOCABULARY_TYPE "
+            "on-disk-compressed-geo-split (default: no grid)",
+        )
         index_args["encode_as_id"] = arg(
             "--encode-as-id",
             type=str,

--- a/test/qlever/commands/test_index_execute.py
+++ b/test/qlever/commands/test_index_execute.py
@@ -47,6 +47,8 @@ class TestIndexCommand(unittest.TestCase):
         args.image = "test_image"
         args.multi_input_json = False
         args.ulimit = None
+        args.geo_cell_grid_level = None
+        args.geo_cell_grid_scheme = None
         args.encode_as_id = None
         args.parser_buffer_size = None
         args.materialized_views = None
@@ -264,6 +266,8 @@ class TestIndexCommand(unittest.TestCase):
         args.image = "test_image"
         args.multi_input_json = False
         args.ulimit = None
+        args.geo_cell_grid_level = None
+        args.geo_cell_grid_scheme = None
         args.encode_as_id = None
         args.parser_buffer_size = None
         args.materialized_views = None
@@ -380,6 +384,8 @@ class TestIndexCommand(unittest.TestCase):
         args.vocabulary_type = "on-disk-compressed"
         args.show = True
         args.ulimit = None
+        args.geo_cell_grid_level = None
+        args.geo_cell_grid_scheme = None
         args.encode_as_id = None
         args.parser_buffer_size = None
         args.materialized_views = None

--- a/test/qlever/commands/test_index_other_methods.py
+++ b/test/qlever/commands/test_index_other_methods.py
@@ -33,6 +33,8 @@ class TestIndexCommand(unittest.TestCase):
                 "index": [
                     "input_files",
                     "cat_input_files",
+                    "geo_cell_grid_level",
+                    "geo_cell_grid_scheme",
                     "encode_as_id",
                     "multi_input_json",
                     "parallel_parsing",


### PR DESCRIPTION
This change adds two Qleverfile options in the `[index]` section, `GEO_CELL_GRID_LEVEL` and `GEO_CELL_GRID_SCHEME`, which are passed through to the index builder as `--geo-cell-grid-level` and `--geo-cell-grid-scheme`. With a level > 0, the index builder annotates the IDs of WKT literals with a grid cell, which enables block prefiltering for spatial joins. The scheme option selects the cell assignment (`flat`, `flat-4-shifts`, `hierarchical`, `hierarchical-3-shifts`).

NOTE: At the time of this merge, these options do not yet exist for `qlever-index`. The code will be added in a series of PRs derived from https://github.com/ad-freiburg/qlever/pull/3310 over the next weeks.