### PR TITLE
Make `qlever start` and `qlever add-text-index` notice when `qlever-server` or `qlever-index` fail

### DIFF
--- a/src/qlever/commands/add_text_index.py
+++ b/src/qlever/commands/add_text_index.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-import subprocess
-
 from qlever.command import QleverCommand
 from qlever.containerize import Containerize
 from qlever.log import log
-from qlever.util import binary_exists, get_existing_index_files
+from qlever.util import (
+    binary_exists,
+    get_existing_index_files,
+    run_command,
+)
 
 
 class AddTextIndexCommand(QleverCommand):
@@ -61,7 +63,7 @@ class AddTextIndexCommand(QleverCommand):
             "from_text_records_and_literals",
         ]:
             add_text_index_cmd += " --text-words-from-literals"
-        add_text_index_cmd += f" | tee {args.name}.text-index-log.txt"
+        add_text_index_cmd += f" 2>&1 | tee {args.name}.text-index-log.txt"
 
         # Run the command in a container (if so desired).
         if args.system in Containerize.supported_systems():
@@ -98,9 +100,9 @@ class AddTextIndexCommand(QleverCommand):
 
         # Run the index command.
         try:
-            subprocess.run(add_text_index_cmd, shell=True, check=True)
+            run_command(add_text_index_cmd, show_output=True)
         except Exception as e:
-            log.error(f'Running "{add_text_index_cmd}" failed ({e})')
+            log.error(f"Adding the text index failed: {e}")
             return False
 
         return True

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import shlex
 import contextlib
+import shlex
 import subprocess
-
-import psutil
 import time
 from collections.abc import Callable
 from pathlib import Path
+
+import psutil
 
 from qlever.command import QleverCommand
 from qlever.commands.cache_stats import CacheStatsCommand

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import shlex
+import contextlib
 import subprocess
+
+import psutil
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -219,12 +222,12 @@ def show_log_follow_info(log_name: str, run_in_foreground: bool) -> None:
 
 
 def make_server_liveness_check(
-    args, process: subprocess.Popen | None
+    args, process: subprocess.Popen | None, pid: int | None
 ) -> Callable[[], bool]:
     """
-    Build a check that tells whether the server started by `process` is
-    still running. With `nohup`, we have no handle on the server
-    process, so the check always says yes.
+    Build a check that tells whether the server is still running: via the
+    container runtime, via the `Popen` handle (foreground), or via the
+    `pid` of the process started with `nohup`.
     """
     if args.system in Containerize.supported_systems():
         return lambda: Containerize.is_running(
@@ -232,6 +235,8 @@ def make_server_liveness_check(
         )
     if args.run_in_foreground:
         return lambda: process.poll() is None
+    if pid is not None:
+        return lambda: psutil.pid_exists(pid)
     return lambda: True
 
 
@@ -386,7 +391,10 @@ class StartCommand(QleverCommand):
         elif args.run_in_foreground:
             start_cmd = f"{start_cmd}"
         else:
-            start_cmd = f"nohup {start_cmd} &"
+            # The `echo $!` reports the PID of the server process, which the
+            # liveness check below uses to detect a server that exits before
+            # it becomes ready (see `make_server_liveness_check`).
+            start_cmd = f"nohup {start_cmd} & echo $!"
 
         # Show the command line.
         self.show(start_cmd, only_show=args.show)
@@ -440,11 +448,26 @@ class StartCommand(QleverCommand):
         log_file.unlink(missing_ok=True)
 
         # Execute the command line.
+        # For a server started with `nohup`, the `echo $!` in the command
+        # reports its PID, which the liveness check below uses (a server in a
+        # container or in the foreground is checked via the container runtime
+        # or the process handle instead, see `make_server_liveness_check`).
+        capture_pid = (
+            not args.run_in_foreground
+            and args.system not in Containerize.supported_systems()
+        )
+        pid = None
         try:
-            process = run_command(
-                start_cmd,
-                use_popen=args.run_in_foreground,
-            )
+            if capture_pid:
+                output = run_command(start_cmd, return_output=True)
+                process = None
+                with contextlib.suppress(ValueError, AttributeError):
+                    pid = int(output.strip().splitlines()[-1])
+            else:
+                process = run_command(
+                    start_cmd,
+                    use_popen=args.run_in_foreground,
+                )
         except Exception as e:
             log.error(f"Starting the QLever server failed ({e})")
             return False
@@ -458,7 +481,7 @@ class StartCommand(QleverCommand):
             return False
         if not wait_until_server_ready(
             lambda: is_qlever_server_alive(args.endpoint_url),
-            make_server_liveness_check(args, process),
+            make_server_liveness_check(args, process, pid),
         ):
             tail_proc.terminate()
             return False

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -437,12 +437,12 @@ class TestStartCommand(unittest.TestCase):
             " -t"
             f" > {args.name}.server-log.txt 2>&1"
         )
-        run_call_2 = f"nohup {start_command} &"
+        run_call_2 = f"nohup {start_command} & echo $!"
         # Assert that run_command was called exactly twice with the
 
         mock_util_run_command.assert_has_calls([call(run_call_1)])
         mock_start_run_command.assert_has_calls(
-            [call(run_call_2, use_popen=False)]
+            [call(run_call_2, return_output=True)]
         )
         # Ensure execution was successful
         self.assertTrue(result)


### PR DESCRIPTION
So far, when the QLever server exited with an error right after being started (for example, because the index has an incompatible format), `qlever start` did not notice. It kept waiting for the server to answer, forever, and had to be interrupted by hand. The reason is that the server is started in the background, and while waiting, `qlever start` only asked whether the server answers, not whether it is still there. It now remembers the process ID of the started server, notices when the process is gone, and fails with the message "Server process exited before becoming ready". The error message of the server itself is visible right above, because the log is shown while waiting.

While at it, fix the analogous problem in qlever add-text-index.