### PR TITLE
Add a `--server-log-mode` option to `qlever start`

### DIFF
--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -94,7 +94,14 @@ def construct_command(args) -> str:
             f" {shlex.quote(view_name)}"
             for view_name in preload_materialized_views
         )
-    start_cmd += f" > {args.name}.server-log.txt 2>&1"
+    if args.server_log_mode == "no-log":
+        # No log file is written. In the foreground, the server output
+        # goes to the terminal; in the background, it is discarded.
+        if not args.run_in_foreground:
+            start_cmd += " > /dev/null 2>&1"
+    else:
+        redirect = ">>" if args.server_log_mode == "append" else ">"
+        start_cmd += f" {redirect} {args.name}.server-log.txt 2>&1"
     return start_cmd
 
 
@@ -201,6 +208,24 @@ def merge_runtime_parameters(
     return list(merged.values())
 
 
+
+
+def rotate_server_log(log_file: Path) -> None:
+    """
+    Move an existing server log to `<log>.1`, first shifting all older
+    generations up by one (`<log>.1` -> `<log>.2`, ...). All generations
+    are kept.
+    """
+    if not log_file.exists():
+        return
+    num_old = 0
+    while Path(f"{log_file}.{num_old + 1}").exists():
+        num_old += 1
+    for i in range(num_old, 0, -1):
+        Path(f"{log_file}.{i}").rename(f"{log_file}.{i + 1}")
+    log_file.rename(f"{log_file}.1")
+
+
 def show_log_follow_info(log_name: str, run_in_foreground: bool) -> None:
     """
     Tell the user which log is being followed, until when, and what
@@ -274,7 +299,8 @@ def wait_for_foreground_server(
         log.info("")
         process.terminate()
         on_interrupt()
-    log_proc.terminate()
+    if log_proc is not None:
+        log_proc.terminate()
 
 
 class StartCommand(QleverCommand):
@@ -319,6 +345,7 @@ class StartCommand(QleverCommand):
                 "resource_usage_log",
                 "resource_usage_interval",
                 "preload_materialized_views",
+                "server_log_mode",
                 "warmup_cmd",
                 "enable_metrics",
             ],
@@ -442,10 +469,17 @@ class StartCommand(QleverCommand):
         #                   f" (use `lsof -i :{port}` to find out which one)")
         #         return False
 
-        # Remove old log file so that the wait loop below correctly
-        # waits for the server to create a fresh one.
+        # Handle an existing log file from a previous server run according
+        # to `--server-log-mode`: keep it and append (`append`), remove it
+        # (`overwrite`), move it to `.1`, `.2`, ... (`rotate`, the
+        # default), or write no log at all (`no-log`). For `overwrite` and
+        # `rotate`, the wait loop below then correctly waits for the server
+        # to create a fresh log.
         log_file = Path(f"{args.name}.server-log.txt")
-        log_file.unlink(missing_ok=True)
+        if args.server_log_mode == "rotate":
+            rotate_server_log(log_file)
+        elif args.server_log_mode == "overwrite":
+            log_file.unlink(missing_ok=True)
 
         # Execute the command line.
         # For a server started with `nohup`, the `echo $!` in the command
@@ -475,15 +509,31 @@ class StartCommand(QleverCommand):
         # Tail the server log until the server is ready (note that the `exec`
         # is important to make sure that the tail process is killed and not
         # just the bash process).
-        show_log_follow_info(str(log_file), args.run_in_foreground)
-        tail_proc = tail_log_file(log_file)
-        if tail_proc is None:
-            return False
+        if args.server_log_mode == "no-log":
+            if args.run_in_foreground:
+                log.info(
+                    "No server log is written, the server output goes to "
+                    "this terminal (Ctrl-C stops the server)"
+                )
+            else:
+                log.info("Server log disabled (`--server-log-mode no-log`)")
+            log.info("")
+            tail_proc = None
+        else:
+            show_log_follow_info(str(log_file), args.run_in_foreground)
+            # With `append`, only follow what the new server run writes,
+            # not the content of the previous runs.
+            tail_proc = tail_log_file(
+                log_file, from_beginning=args.server_log_mode != "append"
+            )
+            if tail_proc is None:
+                return False
         if not wait_until_server_ready(
             lambda: is_qlever_server_alive(args.endpoint_url),
             make_server_liveness_check(args, process, pid),
         ):
-            tail_proc.terminate()
+            if tail_proc is not None:
+                tail_proc.terminate()
             return False
 
         # Set the description for the index and text.
@@ -502,7 +552,7 @@ class StartCommand(QleverCommand):
                 return False
 
         # Kill the tail process. NOTE: `tail_proc.kill()` does not work.
-        if not args.run_in_foreground:
+        if not args.run_in_foreground and tail_proc is not None:
             tail_proc.terminate()
 
         # Execute the warmup command.

--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -208,8 +208,6 @@ def merge_runtime_parameters(
     return list(merged.values())
 
 
-
-
 def rotate_server_log(log_file: Path) -> None:
     """
     Move an existing server log to `<log>.1`, first shifting all older
@@ -284,7 +282,7 @@ def wait_until_server_ready(
 
 def wait_for_foreground_server(
     process: subprocess.Popen,
-    log_proc: subprocess.Popen,
+    log_proc: subprocess.Popen | None,
     on_interrupt: Callable[[], None],
 ) -> None:
     """
@@ -498,10 +496,22 @@ class StartCommand(QleverCommand):
                 with contextlib.suppress(ValueError, AttributeError):
                     pid = int(output.strip().splitlines()[-1])
             else:
-                process = run_command(
-                    start_cmd,
-                    use_popen=args.run_in_foreground,
-                )
+                # For `no-log` in the foreground, the command has no
+                # redirection, so the output must go to the terminal
+                # (otherwise it would fill a pipe that nobody reads and
+                # eventually block the server).
+                if args.run_in_foreground and args.server_log_mode == "no-log":
+                    process = run_command(
+                        start_cmd,
+                        use_popen=True,
+                        show_output=True,
+                        show_stderr=True,
+                    )
+                else:
+                    process = run_command(
+                        start_cmd,
+                        use_popen=args.run_in_foreground,
+                    )
         except Exception as e:
             log.error(f"Starting the QLever server failed ({e})")
             return False

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -460,6 +460,18 @@ class Qleverfile:
             help="Whether to produce the per-query metrics log, a JSONL log of "
             "query start/end events (`.metrics-log.jsonl`)",
         )
+        server_args["server_log_mode"] = arg(
+            "--server-log-mode",
+            choices=["append", "overwrite", "rotate", "no-log"],
+            default="rotate",
+            help="What to do with the server log of a previous run when "
+            "starting the server: `append` = keep it and append, "
+            "`overwrite` = remove it (the behavior before this option "
+            "existed), `rotate` = move it to `<log>.1`, shifting older "
+            "generations up (all are kept), `no-log` = write no server "
+            "log at all (in the foreground, the server output goes to "
+            "the terminal)",
+        )
         server_args["resource_usage_log"] = arg(
             "--resource-usage-log",
             choices=["yes", "no"],

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -760,9 +760,11 @@ def tail_log_file(
     from_beginning: bool = True,
 ) -> subprocess.Popen | None:
     """
-    Wait for the log file to appear and start tailing it from the
-    beginning. The old log file should be deleted before calling this
-    function.
+    Wait for the log file to appear and start tailing it. With
+    `from_beginning`, the whole file is shown (this assumes that the log
+    file of a previous run was deleted or rotated away before calling
+    this function); otherwise, only lines written after the tail starts
+    are shown (for a log file that is appended to).
 
     Returns the tail process, or None if the log file was not created
     within `max_wait_seconds`.

--- a/src/qlever/util.py
+++ b/src/qlever/util.py
@@ -757,6 +757,7 @@ def add_memory_options(subparser, index=True, server=True):
 def tail_log_file(
     log_file: Path,
     max_wait_seconds: int = 30,
+    from_beginning: bool = True,
 ) -> subprocess.Popen | None:
     """
     Wait for the log file to appear and start tailing it from the
@@ -776,7 +777,8 @@ def tail_log_file(
             return None
         time.sleep(0.1)
         waited += 0.1
-    tail_cmd = f"exec tail -n +1 -f {log_file}"
+    tail_from = "+1" if from_beginning else "0"
+    tail_cmd = f"exec tail -n {tail_from} -f {log_file}"
     return subprocess.Popen(tail_cmd, shell=True)
 
 

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -804,3 +804,69 @@ class TestMergeRuntimeParameters(unittest.TestCase):
 
         args = SimpleNamespace(qleverfile="/nonexistent/Qleverfile")
         self.assertEqual(get_runtime_parameters_from_qleverfile(args), [])
+
+
+# Tests that `--server-log-mode append` appends to the server log instead
+# of truncating it, and that `no-log` writes no log at all.
+def test_construct_command_server_log_mode_append_and_no_log():
+    args = MagicMock()
+    args.name = "TestName"
+    args.server_log_mode = "append"
+    args.run_in_foreground = False
+    args.timeout = False
+    args.access_token = False
+    args.persist_updates = False
+    args.rebuild_index_strategy = "manual"
+    args.rebuild_keep_previous_index_dirs = "original-and-most-recent"
+    args.set_runtime_parameters = []
+    args.only_pso_and_pos_permutations = False
+    args.use_patterns = "yes"
+    args.use_text_index = "no"
+    args.enable_metrics = False
+    args.metrics_log = "yes"
+    args.resource_usage_log = "yes"
+    args.resource_usage_interval = 2
+    args.preload_materialized_views = None
+
+    result = qlever.commands.start.construct_command(args)
+    assert result.endswith(f" >> {args.name}.server-log.txt 2>&1")
+
+    # `no-log` in the background discards the output ...
+    args.server_log_mode = "no-log"
+    args.run_in_foreground = False
+    result = qlever.commands.start.construct_command(args)
+    assert result.endswith(" > /dev/null 2>&1")
+    assert "server-log.txt" not in result
+
+    # ... and in the foreground, it goes to the terminal.
+    args.run_in_foreground = True
+    result = qlever.commands.start.construct_command(args)
+    assert "/dev/null" not in result
+    assert "server-log.txt" not in result
+
+
+# Tests the rotation of the server log: the existing log moves to `.1`,
+# older generations shift up, and all generations are kept.
+def test_rotate_server_log(tmp_path):
+    log_file = tmp_path / "TestName.server-log.txt"
+
+    # Rotating a non-existing log does nothing.
+    qlever.commands.start.rotate_server_log(log_file)
+    assert list(tmp_path.iterdir()) == []
+
+    # Rotate four times; all generations are kept, newest first.
+    for run in range(4):
+        log_file.write_text(f"run {run}")
+        qlever.commands.start.rotate_server_log(log_file)
+        assert not log_file.exists()
+    generations = sorted(p.name for p in tmp_path.iterdir())
+    assert generations == [
+        "TestName.server-log.txt.1",
+        "TestName.server-log.txt.2",
+        "TestName.server-log.txt.3",
+        "TestName.server-log.txt.4",
+    ]
+    for i in range(1, 5):
+        expected = f"run {4 - i}"
+        actual = (tmp_path / f"TestName.server-log.txt.{i}").read_text()
+        assert actual == expected

--- a/test/qlever/commands/test_start_other_methods.py
+++ b/test/qlever/commands/test_start_other_methods.py
@@ -50,6 +50,7 @@ class TestStartCommand(unittest.TestCase):
                     "resource_usage_log",
                     "resource_usage_interval",
                     "preload_materialized_views",
+                    "server_log_mode",
                     "warmup_cmd",
                     "enable_metrics",
                 ],


### PR DESCRIPTION
Until now, `qlever start` removed the server log of the previous run before starting the server. This has repeatedly destroyed the evidence needed to diagnose a server crash. The new option `--server-log-mode` (also settable via `SERVER_LOG_MODE` in the `[server]` section of the Qleverfile) controls what happens to an existing `<name>.server-log.txt`:

- `rotate` (the new default): move it to `<log>.1`, shifting older generations up; all generations are kept.
- `overwrite`: remove it (the behavior so far).
- `append`: keep it and append; only the output of the new run is followed on the console.
- `no-log`: write no server log at all; when the server runs in the foreground, its output goes to the terminal.