### PR TITLE
Add option `SECCOMP_PROFILE` for `qlever start`

### DIFF
--- a/src/qlever/commands/start.py
+++ b/src/qlever/commands/start.py
@@ -133,6 +133,7 @@ def wrap_command_in_container(args, start_cmd) -> str:
         volumes=[("$(pwd)", "/index")],
         ports=[(args.port, args.port)],
         working_directory="/index",
+        seccomp_profile=args.seccomp_profile,
     )
     return start_cmd
 
@@ -352,6 +353,7 @@ class StartCommand(QleverCommand):
                 "image",
                 "server_container",
                 "restart_policy",
+                "seccomp_profile",
             ],
         }
 

--- a/src/qlever/containerize.py
+++ b/src/qlever/containerize.py
@@ -41,7 +41,7 @@ class Containerize:
         ports: list[tuple[int, int]] = [],
         working_directory: str | None = None,
         use_bash: bool = True,
-        seccomp_profile: Optional[str] = None,
+        seccomp_profile: str | None = None,
     ) -> str:
         """
         Get the command to run `cmd` with the given `container_system` and the

--- a/src/qlever/containerize.py
+++ b/src/qlever/containerize.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 import shlex
 import subprocess
 
@@ -40,6 +41,7 @@ class Containerize:
         ports: list[tuple[int, int]] = [],
         working_directory: str | None = None,
         use_bash: bool = True,
+        seccomp_profile: Optional[str] = None,
     ) -> str:
         """
         Get the command to run `cmd` with the given `container_system` and the
@@ -75,6 +77,14 @@ class Containerize:
         working_directory_option = (
             f" -w {working_directory}" if working_directory is not None else ""
         )
+        # Optional seccomp profile (absolute path, so that the command works
+        # independently of the directory it is executed from).
+        seccomp_option = (
+            " --security-opt seccomp="
+            + shlex.quote(os.path.abspath(os.path.expanduser(seccomp_profile)))
+            if seccomp_profile
+            else ""
+        )
 
         # Construct the command that runs `cmd` with the given container
         # system.
@@ -87,6 +97,7 @@ class Containerize:
             f"{working_directory_option}"
             f" --name {container_name}"
             f" --init"
+            f"{seccomp_option}"
         )
         if use_bash:
             containerized_cmd += (

--- a/src/qlever/qleverfile.py
+++ b/src/qlever/qleverfile.py
@@ -550,6 +550,19 @@ class Qleverfile:
             " (only applies when running in a container)"
             " (default: unless-stopped)",
         )
+        runtime_args["seccomp_profile"] = arg(
+            "--seccomp-profile",
+            type=str,
+            default=None,
+            help=(
+                "Path to a seccomp profile (JSON file) for the server "
+                "container, passed to the container engine as "
+                "`--security-opt seccomp=<path>`; for example, to allow "
+                "the io_uring syscalls that the default profile blocks "
+                "(default: none, that is, the container engine's default "
+                "profile is used)"
+            ),
+        )
 
         ui_args["ui_port"] = arg(
             "--ui-port",

--- a/test/qlever/commands/test_start_execute.py
+++ b/test/qlever/commands/test_start_execute.py
@@ -148,6 +148,7 @@ def test_wrap_command_in_container(mock_containerize_command):
         volumes=[("$(pwd)", "/index")],
         ports=[(args.port, args.port)],
         working_directory="/index",
+        seccomp_profile=args.seccomp_profile,
     )
     # check start command was successfully returned
     start_command = "Test_Container_Command"

--- a/test/qlever/commands/test_start_other_methods.py
+++ b/test/qlever/commands/test_start_other_methods.py
@@ -59,6 +59,7 @@ class TestStartCommand(unittest.TestCase):
                     "image",
                     "server_container",
                     "restart_policy",
+                    "seccomp_profile",
                 ],
             },
         )

--- a/test/qlever/test_containerize.py
+++ b/test/qlever/test_containerize.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 
 from qlever.containerize import Containerize
 
@@ -33,7 +34,7 @@ def test_containerize_command_with_seccomp_profile():
     cmd = _cmd(seccomp_profile="/etc/qlever/seccomp.json")
     assert " --security-opt seccomp=/etc/qlever/seccomp.json" in cmd
     cmd = _cmd(seccomp_profile="seccomp.json")
-    expected = os.path.join(os.getcwd(), "seccomp.json")
+    expected = shlex.quote(os.path.join(os.getcwd(), "seccomp.json"))
     assert f" --security-opt seccomp={expected}" in cmd
     # The option comes after `--init` and before the image name.
     assert cmd.index("--init") < cmd.index("--security-opt")

--- a/test/qlever/test_containerize.py
+++ b/test/qlever/test_containerize.py
@@ -1,0 +1,40 @@
+import os
+
+from qlever.containerize import Containerize
+
+
+def _cmd(**kwargs) -> str:
+    return Containerize.containerize_command(
+        "echo hello",
+        "docker",
+        "run -d",
+        "adfreiburg/qlever",
+        "qlever.server.test",
+        volumes=[("$(pwd)", "/index")],
+        ports=[(7001, 7001)],
+        working_directory="/index",
+        **kwargs,
+    )
+
+
+# Without a seccomp profile (the default), no `--security-opt` is added, so
+# the container engine's default profile applies.
+def test_containerize_command_without_seccomp_profile():
+    cmd = _cmd()
+    assert "--security-opt" not in cmd
+    assert "seccomp" not in cmd
+    cmd = _cmd(seccomp_profile=None)
+    assert "--security-opt" not in cmd
+
+
+# With a seccomp profile, `--security-opt seccomp=<abspath>` is added, where
+# a relative path is made absolute w.r.t. the current working directory.
+def test_containerize_command_with_seccomp_profile():
+    cmd = _cmd(seccomp_profile="/etc/qlever/seccomp.json")
+    assert " --security-opt seccomp=/etc/qlever/seccomp.json" in cmd
+    cmd = _cmd(seccomp_profile="seccomp.json")
+    expected = os.path.join(os.getcwd(), "seccomp.json")
+    assert f" --security-opt seccomp={expected}" in cmd
+    # The option comes after `--init` and before the image name.
+    assert cmd.index("--init") < cmd.index("--security-opt")
+    assert cmd.index("--security-opt") < cmd.index("adfreiburg/qlever")


### PR DESCRIPTION
So far, `qlever start` ran the server container with the default seccomp profile of the container engine. The default profile of Docker blocks the io_uring syscalls, so a server started this way logs `io_uring is compiled in but unavailable at runtime` and falls back to synchronous `pread` for vocabulary lookups.

This change adds the option `SECCOMP_PROFILE` in the `[runtime]` section of the Qleverfile (also `qlever start --seccomp-profile`), which is passed to the container engine as `--security-opt seccomp=<path>`. With a profile that additionally allows `io_uring_setup`, `io_uring_enter`, and `io_uring_register`, the server uses the io_uring path. Without the option, nothing changes. Only `qlever start` gets the option, because the io_uring rings are created when a vocabulary is opened for reading, which the index builder never does.